### PR TITLE
feat: add tox configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# byte-compiled
+__pycache__/
+*.pyc
+
+# distribution / packaging
+build/
+*.egg-info/
+
+# unit test / coverage reports
+.coverage
+coverage.xml
+.tox/
+
+# local binaries
+bin
+
+# virtual environment
+venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,46 @@
+[project]
+name = "diffused"
+version = "0.1.0"
+description = ""
+readme = "README.md"
+requires-python = ">3.10,<4.0"
+authors = [
+    {name = "Willian Rampazzo"},
+    {email = "willianr@redhat.com"},
+]
+
+dependencies = [
+    "click",
+]
+
+[project.optional-dependencies]
+dev = [
+    "tox",
+    "diffused[black]",
+    "diffused[flake8]",
+    "diffused[isort]",
+    "diffused[mypy]",
+    "diffused[pytest]",
+]
+black = [
+    "black",
+]
+flake8 = [
+    "flake8",
+]
+isort = [
+    "isort",
+]
+mypy = [
+    "mypy",
+]
+pytest = [
+    "pytest",
+    "pytest-cov",
+    "pytest-asyncio",
+    "setuptools",
+]
+
+[project.urls]
+documentation = "https://github.com/konflux-ci/diffused/tree/main/docs"
+repository = "https://github.com/konflux-ci/diffused"

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,43 @@
+[vars]
+SOURCE = src/diffused
+TESTS = src/tests
+
+[tox]
+envlist = black, flake8, isort, mypy, pytest
+isolated_build = True
+
+[testenv]
+setenv = PYTHONHASHSEED = 0
+
+[testenv:black]
+extras = common, black
+commands = black --line-length 100 --check --diff {[vars]SOURCE} {[vars]TESTS}
+
+[testenv:black-format]
+extras = common, black
+commands = black --line-length 100 {[vars]SOURCE} {[vars]TESTS}
+
+[testenv:flake8]
+extras = common, flake8
+commands= python3 -m flake8 --max-line-length=100 {[vars]SOURCE}
+
+[testenv:isort]
+extras = common, isort
+commands = isort --line-length 100 --profile black --check --diff {[vars]SOURCE} {[vars]TESTS}
+
+[testenv:mypy]
+extras = common, mypy
+commands = mypy --install-types --non-interactive \
+                --ignore-missing-imports {[vars]SOURCE} {[vars]TESTS}
+
+[testenv:pytest]
+extras = common, pytest
+commands =
+    pytest \
+        --verbose \
+        --cov={[vars]SOURCE} \
+        --cov-report=term-missing \
+        --cov-fail-under 95 \
+        --cov-report xml \
+        --cov-report html \
+        {[vars]TESTS}


### PR DESCRIPTION
Adds the tox configuration file enabling black, flake8, isort, mypy, and pytest.

Adds a minimal pyproject.toml with the tox dependencies.