### PR TITLE
feat: Add ACS scanner support for vulnerability detection

### DIFF
--- a/src/diffused/cli.py
+++ b/src/diffused/cli.py
@@ -114,7 +114,17 @@ def cli(ctx: click.core.Context) -> None:
     help="File to write the output to.",
     required=False,
 )
-def sbom_diff(previous_sbom: str, next_sbom: str, all_info: bool, output: str, file: IO[str]):
+@click.option(
+    "-s",
+    "--scanner",
+    type=click.Choice(["trivy"], case_sensitive=False),
+    default="trivy",
+    help="Scanner to use for vulnerability detection (only trivy is supported for SBOM scanning).",
+    required=False,
+)
+def sbom_diff(
+    previous_sbom: str, next_sbom: str, all_info: bool, output: str, file: IO[str], scanner: str
+):
     """Show the vulnerability diff between two SBOMs."""
     if not os.path.isfile(previous_sbom):
         click.echo(f"Could not find {previous_sbom}")
@@ -123,7 +133,9 @@ def sbom_diff(previous_sbom: str, next_sbom: str, all_info: bool, output: str, f
         click.echo(f"Could not find {next_sbom}")
         exit(1)
 
-    vuln_differ = VulnerabilityDiffer(previous_sbom=previous_sbom, next_sbom=next_sbom)
+    vuln_differ = VulnerabilityDiffer(
+        previous_sbom=previous_sbom, next_sbom=next_sbom, scanner=scanner
+    )
 
     if output == "json":
         if not all_info:
@@ -176,7 +188,17 @@ def sbom_diff(previous_sbom: str, next_sbom: str, all_info: bool, output: str, f
     help="File to write the output to.",
     required=False,
 )
-def image_diff(previous_image: str, next_image: str, all_info: bool, output: str, file: IO[str]):
+@click.option(
+    "-s",
+    "--scanner",
+    type=click.Choice(["acs", "trivy"], case_sensitive=False),
+    default="trivy",
+    help="Scanner to use for vulnerability detection (default=trivy).",
+    required=False,
+)
+def image_diff(
+    previous_image: str, next_image: str, all_info: bool, output: str, file: IO[str], scanner: str
+):
     """Show the vulnerability diff between two container images."""
     if os.path.isfile(previous_image) or os.path.isfile(next_image):
         click.echo(
@@ -185,7 +207,9 @@ def image_diff(previous_image: str, next_image: str, all_info: bool, output: str
         )
         exit(1)
 
-    vuln_differ = VulnerabilityDiffer(previous_image=previous_image, next_image=next_image)
+    vuln_differ = VulnerabilityDiffer(
+        previous_image=previous_image, next_image=next_image, scanner=scanner
+    )
 
     if output == "json":
         if not all_info:

--- a/src/diffused/scanners/acs.py
+++ b/src/diffused/scanners/acs.py
@@ -1,0 +1,196 @@
+"""ACS scanner implementation."""
+
+import json
+import logging
+import os
+import subprocess
+
+from diffused.scanners.base import BaseScanner
+from diffused.scanners.models import Package
+
+logger = logging.getLogger(__name__)
+
+
+class ACSScanner(BaseScanner):
+    """ACS scanner class."""
+
+    def __init__(self, sbom: str | None = None, image: str | None = None):
+        super().__init__(sbom, image)
+        self._validate_environment()
+
+    def _validate_environment(self) -> None:
+        """Validates required environment variables are set."""
+        if not os.getenv("ROX_ENDPOINT") or not os.getenv("ROX_API_TOKEN"):
+            error_message = (
+                "ROX_ENDPOINT and ROX_API_TOKEN must be set in the environment variables."
+            )
+            logger.error(error_message)
+            self.error = error_message
+            raise ValueError(error_message)
+
+    def _run_acs_command(self, cmd: list[str], operation: str) -> subprocess.CompletedProcess:
+        """Helper method to run ACS commands."""
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                shell=False,
+                text=True,
+                timeout=120,  # 2 minutes timeout
+            )
+            result.check_returncode()
+            return result
+        except subprocess.CalledProcessError as e:
+            error_message = f"ACS {operation} failed. Return code: {e.returncode}."
+            if e.stderr:
+                error_message += f" Error output: {e.stderr}"
+            logger.error(error_message)
+            self.error = error_message
+            raise
+        except subprocess.TimeoutExpired:
+            error_message = f"ACS {operation} timed out."
+            logger.error(error_message)
+            self.error = error_message
+            raise
+        except Exception as e:
+            error_message = f"Unexpected error during ACS {operation}: {e}."
+            logger.error(error_message)
+            self.error = error_message
+            raise
+
+    def retrieve_sbom(self, output_file: str) -> None:
+        """Retrieves the SBOM from a container image."""
+        if not self.image:
+            raise ValueError("You must set the image to retrieve the SBOM.")
+        if not output_file:
+            raise ValueError("You must set the output_file with a valid path to retrieve the SBOM.")
+
+        # command to generate the sbom
+        cmd = [
+            "roxctl",
+            "--no-color",
+            "image",
+            "sbom",
+            "--image",
+            self.image,
+        ]
+
+        try:
+            result = self._run_acs_command(cmd, f"SBOM generation for {self.image}")
+            parsed_output = json.loads(result.stdout)
+
+            with open(output_file, "w") as f:
+                json.dump(parsed_output, f, indent=2)
+
+            # Set the sbom path after successful generation
+            self.sbom = output_file
+            logger.info(f"Successfully generated SBOM for {self.image} at {output_file}.")
+        except json.JSONDecodeError as e:
+            error_message = f"Error parsing SBOM output for {self.image}: {e}."
+            logger.error(error_message)
+            self.error = error_message
+        except Exception:
+            # Error already logged and stored in self.error by _run_acs_command
+            pass
+
+    def scan_sbom(self) -> None:
+        """Performs a scan on a given SBOM."""
+        # The ACS scanner does not support SBOM scanning yet.
+        logger.warning(
+            "Image %s: SBOM scanning is not supported by ACS yet. Falling back to image scanning.",
+            self.image,
+        )
+
+        if not self.image:
+            raise ValueError("You must set the image to scan.")
+
+        cmd = [
+            "roxctl",
+            "--no-color",
+            "image",
+            "scan",
+            "--output",
+            "json",
+            "--image",
+            self.image,
+        ]
+
+        try:
+            result = self._run_acs_command(cmd, f"Image scan for {self.image}")
+            self.raw_result = json.loads(result.stdout)
+            logger.info(f"Successfully scanned image {self.image}")
+        except json.JSONDecodeError as e:
+            error_message = f"Error parsing ACS output for {self.image}: {e}."
+            logger.error(error_message)
+            self.error = error_message
+        except Exception:
+            # Error already logged and stored in self.error by _run_acs_command
+            pass
+
+    def process_result(self) -> None:
+        """Processes the desired data from the given scan result."""
+        if self.raw_result is None:
+            raise ValueError("Run a scan before processing its output.")
+
+        # Clear previous results
+        self.processed_result.clear()
+
+        # If the image does not have vulnerabilities tracked, keep the list empty
+        if "result" not in self.raw_result or "vulnerabilities" not in self.raw_result["result"]:
+            logger.info("No vulnerabilities found in scan results.")
+            return
+
+        # Use defaultdict for automatic set creation and better performance
+        vulnerability_count = 0
+        skipped_count = 0
+
+        # Process vulnerabilities directly without creating intermediate collections
+        vulnerabilities = self.raw_result["result"]["vulnerabilities"]
+        for vulnerability in vulnerabilities:
+            vulnerability_id = vulnerability.get("cveId")
+            if not vulnerability_id:
+                skipped_count += 1
+                continue
+
+            pkg_info = Package(
+                name=vulnerability.get("componentName", ""),
+                version=vulnerability.get("componentVersion", ""),
+            )
+
+            if vulnerability_id not in self.processed_result:
+                self.processed_result[vulnerability_id] = set()
+            self.processed_result[vulnerability_id].add(pkg_info)
+            vulnerability_count += 1
+
+        # Log processing results
+        unique_vulnerabilities = len(self.processed_result)
+        if unique_vulnerabilities == 0:
+            logger.info("No vulnerabilities found in any result content.")
+        else:
+            logger.info(
+                "Processed %d vulnerabilities into %d unique vulnerability IDs.",
+                vulnerability_count,
+                unique_vulnerabilities,
+            )
+            if skipped_count > 0:
+                logger.warning("Skipped %d vulnerabilities without IDs.", skipped_count)
+
+    @staticmethod
+    def get_version() -> str:
+        """Returns ACS scanner version."""
+        try:
+            result = subprocess.run(
+                ["roxctl", "version"], capture_output=True, shell=False, text=True, timeout=10
+            )
+            result.check_returncode()
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+            error_message = f"Failed to get ACS version: {str(e)}"
+            logger.error(error_message)
+            return "unknown"
+        except Exception as e:
+            error_message = f"Unexpected error during ACS version check: {e}."
+            logger.error(error_message)
+            return "unknown"
+
+        return result.stdout.strip()

--- a/src/tests/scanners/conftest.py
+++ b/src/tests/scanners/conftest.py
@@ -1,0 +1,140 @@
+"""Shared fixtures for scanner tests."""
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def rox_env():
+    """Fixture to provide valid ROX environment variables."""
+    with patch.dict(
+        "os.environ", {"ROX_ENDPOINT": "https://localhost:8443", "ROX_API_TOKEN": "test-token"}
+    ):
+        yield
+
+
+@pytest.fixture
+def test_image():
+    """Fixture to provide a consistent test image name."""
+    return "test-image:latest"
+
+
+@pytest.fixture
+def test_sbom_path():
+    """Fixture to provide a consistent test SBOM path."""
+    return "/path/to/sbom.json"
+
+
+@pytest.fixture
+def test_output_path():
+    """Fixture to provide a consistent test output path."""
+    return "/path/to/output.json"
+
+
+@pytest.fixture
+def sample_vulnerabilities():
+    """Fixture to provide sample vulnerability data for testing."""
+    return [
+        {
+            "cveId": "CVE-2023-1234",
+            "componentName": "package1",
+            "componentVersion": "1.0.0",
+        },
+        {
+            "cveId": "CVE-2023-5678",
+            "componentName": "package2",
+            "componentVersion": "2.0.0",
+        },
+        {
+            "cveId": "CVE-2023-1234",  # Duplicate vulnerability
+            "componentName": "package3",
+            "componentVersion": "1.5.0",
+        },
+    ]
+
+
+@pytest.fixture
+def sample_acs_response(sample_vulnerabilities):
+    """Fixture to provide a sample ACS response with vulnerabilities."""
+    return {"result": {"vulnerabilities": sample_vulnerabilities}}
+
+
+@pytest.fixture
+def empty_acs_response():
+    """Fixture to provide an empty ACS response."""
+    return {"result": {"vulnerabilities": []}}
+
+
+@pytest.fixture
+def vulnerabilities_without_cve_id():
+    """Fixture to provide vulnerability data with missing CVE IDs for testing filtering."""
+    return [
+        {
+            "cveId": "CVE-2023-1234",
+            "componentName": "package1",
+            "componentVersion": "1.0.0",
+        },
+        {
+            "componentName": "package2",
+            "componentVersion": "2.0.0",
+            # Missing cveId
+        },
+    ]
+
+
+@pytest.fixture
+def mixed_vulnerability_data():
+    """Fixture to provide mixed vulnerability data (some with IDs, some without)."""
+    return [
+        {
+            "cveId": "CVE-2023-1234",
+            "componentName": "package1",
+            "componentVersion": "1.0.0",
+        },
+        {
+            "cveId": "",  # Empty CVE ID
+            "componentName": "package2",
+            "componentVersion": "2.0.0",
+        },
+        {
+            # Missing cveId entirely
+            "componentName": "package3",
+            "componentVersion": "3.0.0",
+        },
+        {
+            "cveId": "CVE-2023-5678",
+            "componentName": "package4",
+            "componentVersion": "4.0.0",
+        },
+    ]
+
+
+@pytest.fixture
+def integration_vulnerability_data():
+    """Fixture to provide vulnerability data for integration testing."""
+    return [
+        {
+            "cveId": "CVE-2023-1234",
+            "componentName": "package1",
+            "componentVersion": "1.0.0",
+        }
+    ]
+
+
+@pytest.fixture
+def vulnerabilities_without_cve_id_response(vulnerabilities_without_cve_id):
+    """Fixture to provide ACS response with vulnerabilities missing CVE IDs."""
+    return {"result": {"vulnerabilities": vulnerabilities_without_cve_id}}
+
+
+@pytest.fixture
+def mixed_vulnerability_response(mixed_vulnerability_data):
+    """Fixture to provide ACS response with mixed vulnerability data."""
+    return {"result": {"vulnerabilities": mixed_vulnerability_data}}
+
+
+@pytest.fixture
+def integration_acs_response(integration_vulnerability_data):
+    """Fixture to provide ACS response for integration testing."""
+    return {"result": {"vulnerabilities": integration_vulnerability_data}}

--- a/src/tests/scanners/test_acs.py
+++ b/src/tests/scanners/test_acs.py
@@ -1,0 +1,491 @@
+"""Unit tests for ACSScanner class."""
+
+import json
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from diffused.scanners.acs import ACSScanner
+from diffused.scanners.models import Package
+
+# Test constants
+COMMAND_TIMEOUT = 120
+VERSION_TIMEOUT = 10
+SUCCESS_RETURN_CODE = 0
+ERROR_RETURN_CODE = 1
+UNKNOWN_VERSION = "unknown"
+
+# Command constants
+ROXCTL_VERSION_COMMAND = ["roxctl", "version"]
+ROXCTL_BASE_ARGS = ["roxctl", "--no-color"]
+ROXCTL_SBOM_ARGS = ROXCTL_BASE_ARGS + ["image", "sbom"]
+ROXCTL_SCAN_ARGS = ROXCTL_BASE_ARGS + ["image", "scan", "--output", "json"]
+
+# Error message patterns
+MISSING_ENV_VARS_ERROR = "ROX_ENDPOINT and ROX_API_TOKEN must be set in the environment variables"
+MISSING_IMAGE_ERROR = "You must set the image to retrieve the SBOM"
+MISSING_OUTPUT_FILE_ERROR = "You must set the output_file with a valid path"
+MISSING_IMAGE_SCAN_ERROR = "You must set the image to scan"
+NO_RAW_RESULT_ERROR = "Run a scan before processing its output"
+
+
+def create_mock_result(stdout="", returncode=SUCCESS_RETURN_CODE):
+    """Helper to create a mock subprocess result."""
+    mock_result = MagicMock()
+    mock_result.stdout = stdout
+    mock_result.returncode = returncode
+    return mock_result
+
+
+def create_scanner_with_image(test_image):
+    """Helper to create ACSScanner with image."""
+    return ACSScanner(image=test_image)
+
+
+def create_scanner_with_sbom(test_sbom_path):
+    """Helper to create ACSScanner with SBOM."""
+    return ACSScanner(sbom=test_sbom_path)
+
+
+def assert_default_scanner_state(scanner, expected_image=None, expected_sbom=None):
+    """Helper to assert scanner is in default state."""
+    assert scanner.image == expected_image
+    assert scanner.sbom == expected_sbom
+    assert scanner.raw_result is None
+    assert scanner.processed_result == {}
+    assert scanner.error == ""
+
+
+def assert_cve_packages_match(processed_result, cve_id, expected_packages):
+    """Helper to assert CVE packages match expected list."""
+    assert cve_id in processed_result
+    cve_packages = processed_result[cve_id]
+    assert len(cve_packages) == len(expected_packages)
+    for package in expected_packages:
+        assert package in cve_packages
+
+
+def assert_vulnerability_processing_results(processed_result, expected_cve_count, expected_cves):
+    """Helper to assert vulnerability processing results."""
+    assert len(processed_result) == expected_cve_count
+    for cve_id in expected_cves:
+        assert cve_id in processed_result
+
+
+def test_initialization_succeeds_with_valid_image(rox_env, test_image):
+    """Test ACSScanner initializes successfully when provided with a valid image."""
+    scanner = create_scanner_with_image(test_image)
+    assert_default_scanner_state(scanner, expected_image=test_image)
+
+
+def test_initialization_succeeds_with_valid_sbom_path(rox_env, test_sbom_path):
+    """Test ACSScanner initializes successfully when provided with a valid SBOM path."""
+    scanner = create_scanner_with_sbom(test_sbom_path)
+    assert_default_scanner_state(scanner, expected_sbom=test_sbom_path)
+
+
+def test_initialization_succeeds_with_both_image_and_sbom(rox_env, test_image, test_sbom_path):
+    """Test ACSScanner initializes successfully when provided with both image and SBOM path."""
+    scanner = ACSScanner(image=test_image, sbom=test_sbom_path)
+    assert scanner.image == test_image
+    assert scanner.sbom == test_sbom_path
+
+
+def test_initialization_fails_when_neither_image_nor_sbom_provided():
+    """Test ACSScanner initialization raises ValueError when neither image nor SBOM is provided."""
+    with pytest.raises(ValueError, match="You must set sbom or image"):
+        ACSScanner()
+
+
+@pytest.mark.parametrize(
+    "env_vars",
+    [
+        {},  # Missing both variables
+        {"ROX_API_TOKEN": "test-token"},  # Missing ROX_ENDPOINT
+        {"ROX_ENDPOINT": "https://localhost:8443"},  # Missing ROX_API_TOKEN
+    ],
+)
+def test_initialization_fails_with_missing_environment_variables(env_vars, test_image):
+    """Test ACSScanner initialization fails when ROX environment variables are missing."""
+    with patch.dict("os.environ", env_vars, clear=True):
+        with pytest.raises(ValueError, match=MISSING_ENV_VARS_ERROR):
+            ACSScanner(image=test_image)
+
+
+@patch("diffused.scanners.acs.subprocess.run")
+def test_acs_command_execution_succeeds_with_valid_subprocess_result(mock_run, rox_env, test_image):
+    """Test _run_acs_command executes successfully when subprocess returns valid result."""
+    scanner = create_scanner_with_image(test_image)
+    mock_result = create_mock_result(returncode=SUCCESS_RETURN_CODE)
+    mock_run.return_value = mock_result
+
+    result = scanner._run_acs_command(ROXCTL_VERSION_COMMAND, "test operation")
+
+    mock_run.assert_called_once_with(
+        ROXCTL_VERSION_COMMAND, capture_output=True, shell=False, text=True, timeout=COMMAND_TIMEOUT
+    )
+    assert result == mock_result
+
+
+@patch("diffused.scanners.acs.subprocess.run")
+def test_acs_command_execution_handles_subprocess_called_process_error(
+    mock_run, rox_env, test_image
+):
+    """Test _run_acs_command properly handles and re-raises CalledProcessError from subprocess."""
+    scanner = create_scanner_with_image(test_image)
+    mock_run.side_effect = subprocess.CalledProcessError(
+        ERROR_RETURN_CODE, ROXCTL_VERSION_COMMAND, stderr="error output"
+    )
+
+    with pytest.raises(subprocess.CalledProcessError):
+        scanner._run_acs_command(ROXCTL_VERSION_COMMAND, "test operation")
+
+    assert "ACS test operation failed" in scanner.error
+    assert "error output" in scanner.error
+
+
+@patch("diffused.scanners.acs.subprocess.run")
+def test_acs_command_execution_handles_subprocess_timeout_error(mock_run, rox_env, test_image):
+    """Test _run_acs_command properly handles and re-raises TimeoutExpired from subprocess."""
+    scanner = create_scanner_with_image(test_image)
+    mock_run.side_effect = subprocess.TimeoutExpired(ROXCTL_VERSION_COMMAND, COMMAND_TIMEOUT)
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        scanner._run_acs_command(ROXCTL_VERSION_COMMAND, "test operation")
+
+    assert "ACS test operation timed out" in scanner.error
+
+
+@patch("diffused.scanners.acs.subprocess.run")
+def test_acs_command_execution_handles_unexpected_subprocess_error(mock_run, rox_env, test_image):
+    """Test _run_acs_command properly handles and re-raises unexpected exceptions from subprocess."""
+    scanner = create_scanner_with_image(test_image)
+    mock_run.side_effect = Exception("Unexpected error")
+
+    with pytest.raises(Exception):
+        scanner._run_acs_command(ROXCTL_VERSION_COMMAND, "test operation")
+
+    assert "Unexpected error during ACS test operation" in scanner.error
+
+
+@patch.object(ACSScanner, "_run_acs_command")
+def test_sbom_retrieval_succeeds_with_valid_image_and_output_path(
+    mock_run_command, rox_env, test_image, test_output_path
+):
+    """Test SBOM retrieval completes successfully when provided with valid image and output path."""
+    scanner = create_scanner_with_image(test_image)
+    mock_result = create_mock_result(stdout='{"packages": []}')
+    mock_run_command.return_value = mock_result
+
+    with patch("builtins.open", MagicMock()) as mock_open:
+        scanner.retrieve_sbom(test_output_path)
+
+    mock_run_command.assert_called_once_with(
+        ROXCTL_SBOM_ARGS + ["--image", test_image],
+        f"SBOM generation for {test_image}",
+    )
+    assert scanner.sbom == test_output_path
+
+
+def test_sbom_retrieval_fails_when_scanner_has_no_image(rox_env, test_sbom_path, test_output_path):
+    """Test SBOM retrieval raises ValueError when scanner was initialized without an image."""
+    scanner = create_scanner_with_sbom(test_sbom_path)
+    with pytest.raises(ValueError, match=MISSING_IMAGE_ERROR):
+        scanner.retrieve_sbom(test_output_path)
+
+
+def test_sbom_retrieval_fails_when_no_output_path_provided(rox_env, test_image):
+    """Test SBOM retrieval raises ValueError when no output file path is provided."""
+    scanner = create_scanner_with_image(test_image)
+    with pytest.raises(ValueError, match=MISSING_OUTPUT_FILE_ERROR):
+        scanner.retrieve_sbom("")
+
+
+@patch.object(ACSScanner, "_run_acs_command")
+def test_sbom_retrieval_handles_command_execution_failure_gracefully(
+    mock_run_command, rox_env, test_image, test_output_path
+):
+    """Test SBOM retrieval handles subprocess command failure without raising exception."""
+    scanner = create_scanner_with_image(test_image)
+    mock_run_command.side_effect = subprocess.CalledProcessError(1, ["roxctl"])
+
+    scanner.retrieve_sbom(test_output_path)
+
+    # Should not raise exception, error should be stored
+    assert scanner.sbom is None  # Should not be set on failure
+
+
+@patch.object(ACSScanner, "_run_acs_command")
+def test_sbom_retrieval_handles_invalid_json_output_gracefully(
+    mock_run_command, rox_env, test_image, test_output_path
+):
+    """Test SBOM retrieval handles invalid JSON output from command without raising exception."""
+    scanner = create_scanner_with_image(test_image)
+    mock_result = create_mock_result(stdout="invalid json output")
+    mock_run_command.return_value = mock_result
+
+    scanner.retrieve_sbom(test_output_path)
+
+    # Should not raise exception, error should be stored
+    assert scanner.sbom is None  # Should not be set on failure
+    assert f"Error parsing SBOM output for {test_image}" in scanner.error
+
+
+@patch.object(ACSScanner, "_run_acs_command")
+def test_image_scanning_succeeds_with_valid_image_and_empty_response(
+    mock_run_command, rox_env, test_image, empty_acs_response
+):
+    """Test image scanning completes successfully when provided with valid image and returns empty response."""
+    scanner = create_scanner_with_image(test_image)
+    mock_result = create_mock_result(stdout=json.dumps(empty_acs_response))
+    mock_run_command.return_value = mock_result
+
+    scanner.scan_sbom()
+
+    mock_run_command.assert_called_once_with(
+        ROXCTL_SCAN_ARGS + ["--image", test_image],
+        f"Image scan for {test_image}",
+    )
+    assert scanner.raw_result == empty_acs_response
+
+
+def test_image_scanning_fails_when_scanner_has_no_image(rox_env, test_sbom_path):
+    """Test image scanning raises ValueError when scanner was initialized without an image."""
+    scanner = create_scanner_with_sbom(test_sbom_path)
+    with pytest.raises(ValueError, match=MISSING_IMAGE_SCAN_ERROR):
+        scanner.scan_sbom()
+
+
+@patch.object(ACSScanner, "_run_acs_command")
+def test_image_scanning_handles_invalid_json_output_gracefully(
+    mock_run_command, rox_env, test_image
+):
+    """Test image scanning handles invalid JSON output from command without raising exception."""
+    scanner = create_scanner_with_image(test_image)
+    mock_result = create_mock_result(stdout="invalid json")
+    mock_run_command.return_value = mock_result
+
+    scanner.scan_sbom()
+
+    assert "Error parsing ACS output" in scanner.error
+    assert scanner.raw_result is None
+
+
+@patch.object(ACSScanner, "_run_acs_command")
+def test_image_scanning_handles_command_execution_failure_gracefully(
+    mock_run_command, rox_env, test_image
+):
+    """Test image scanning handles subprocess command failure without raising exception."""
+    scanner = create_scanner_with_image(test_image)
+    mock_run_command.side_effect = subprocess.CalledProcessError(1, ["roxctl"])
+
+    scanner.scan_sbom()
+
+    # Should not raise exception, error should be stored
+    assert scanner.raw_result is None
+
+
+def test_result_processing_fails_when_no_scan_data_available(rox_env, test_image):
+    """Test result processing raises ValueError when no raw scan data is available."""
+    scanner = create_scanner_with_image(test_image)
+    with pytest.raises(ValueError, match=NO_RAW_RESULT_ERROR):
+        scanner.process_result()
+
+
+def test_result_processing_succeeds_with_empty_vulnerability_data(rox_env, test_image):
+    """Test result processing completes successfully when raw result contains no vulnerability data."""
+    scanner = create_scanner_with_image(test_image)
+    scanner.raw_result = {"result": {}}
+
+    scanner.process_result()
+
+    assert scanner.processed_result == {}
+
+
+def test_result_processing_succeeds_with_empty_vulnerability_array(
+    rox_env, test_image, empty_acs_response
+):
+    """Test result processing completes successfully when vulnerability array is empty."""
+    scanner = create_scanner_with_image(test_image)
+    scanner.raw_result = empty_acs_response
+
+    scanner.process_result()
+
+    assert scanner.processed_result == {}
+
+
+def test_result_processing_groups_vulnerabilities_by_cve_id_correctly(
+    rox_env, test_image, sample_acs_response
+):
+    """Test result processing correctly groups vulnerabilities by CVE ID and handles duplicates."""
+    scanner = create_scanner_with_image(test_image)
+    scanner.raw_result = sample_acs_response
+
+    scanner.process_result()
+
+    assert_vulnerability_processing_results(
+        scanner.processed_result,
+        expected_cve_count=2,
+        expected_cves=["CVE-2023-1234", "CVE-2023-5678"],
+    )
+
+    # Check that CVE-2023-1234 has both packages
+    assert_cve_packages_match(
+        scanner.processed_result,
+        "CVE-2023-1234",
+        [Package(name="package1", version="1.0.0"), Package(name="package3", version="1.5.0")],
+    )
+
+    # Check that CVE-2023-5678 has one package
+    assert_cve_packages_match(
+        scanner.processed_result, "CVE-2023-5678", [Package(name="package2", version="2.0.0")]
+    )
+
+
+def test_result_processing_skips_vulnerabilities_without_cve_id(
+    rox_env, test_image, vulnerabilities_without_cve_id_response
+):
+    """Test result processing ignores vulnerabilities that are missing or have empty CVE IDs."""
+    scanner = create_scanner_with_image(test_image)
+    scanner.raw_result = vulnerabilities_without_cve_id_response
+
+    scanner.process_result()
+
+    assert_vulnerability_processing_results(
+        scanner.processed_result, expected_cve_count=1, expected_cves=["CVE-2023-1234"]
+    )
+
+
+def test_result_processing_clears_previous_processed_data(rox_env, test_image, empty_acs_response):
+    """Test result processing clears any previously processed vulnerability data before processing new results."""
+    scanner = create_scanner_with_image(test_image)
+    scanner.processed_result.clear()
+    scanner.processed_result["CVE-2023-OLD"] = {Package(name="old", version="1.0.0")}
+    scanner.raw_result = empty_acs_response
+
+    scanner.process_result()
+
+    assert scanner.processed_result == {}
+
+
+@patch("diffused.scanners.acs.subprocess.run")
+def test_version_retrieval_succeeds_with_valid_roxctl_output(mock_run, rox_env):
+    """Test version retrieval returns correct version when roxctl command executes successfully."""
+    mock_result = create_mock_result(
+        stdout="roxctl version 4.0.0\n", returncode=SUCCESS_RETURN_CODE
+    )
+    mock_run.return_value = mock_result
+
+    version = ACSScanner.get_version()
+
+    mock_run.assert_called_once_with(
+        ROXCTL_VERSION_COMMAND, capture_output=True, shell=False, text=True, timeout=VERSION_TIMEOUT
+    )
+    assert version == "roxctl version 4.0.0"
+
+
+@patch("diffused.scanners.acs.subprocess.run")
+def test_version_retrieval_returns_unknown_on_subprocess_error(mock_run, rox_env):
+    """Test version retrieval returns 'unknown' when subprocess raises CalledProcessError."""
+    mock_run.side_effect = subprocess.CalledProcessError(ERROR_RETURN_CODE, ROXCTL_VERSION_COMMAND)
+
+    version = ACSScanner.get_version()
+
+    assert version == UNKNOWN_VERSION
+
+
+@patch("diffused.scanners.acs.subprocess.run")
+def test_version_retrieval_returns_unknown_on_subprocess_timeout(mock_run, rox_env):
+    """Test version retrieval returns 'unknown' when subprocess times out."""
+    mock_run.side_effect = subprocess.TimeoutExpired(ROXCTL_VERSION_COMMAND, VERSION_TIMEOUT)
+
+    version = ACSScanner.get_version()
+
+    assert version == UNKNOWN_VERSION
+
+
+@patch("diffused.scanners.acs.subprocess.run")
+def test_version_retrieval_returns_unknown_on_unexpected_error(mock_run, rox_env):
+    """Test version retrieval returns 'unknown' when subprocess raises unexpected exception."""
+    mock_run.side_effect = Exception("Unexpected error")
+
+    version = ACSScanner.get_version()
+
+    assert version == UNKNOWN_VERSION
+
+
+def test_complete_workflow_executes_all_operations_successfully(
+    rox_env, test_image, test_sbom_path, integration_acs_response
+):
+    """Test complete workflow of SBOM retrieval, image scanning, and result processing executes successfully."""
+    scanner = create_scanner_with_image(test_image)
+
+    # Mock the entire workflow
+    with patch.object(scanner, "_run_acs_command") as mock_run:
+        # Test retrieve_sbom
+        mock_result = create_mock_result(stdout='{"packages": []}')
+        mock_run.return_value = mock_result
+
+        with patch("builtins.open", MagicMock()):
+            scanner.retrieve_sbom(test_sbom_path)
+        assert scanner.sbom == test_sbom_path
+
+        # Test scan_sbom
+        mock_result = create_mock_result(stdout=json.dumps(integration_acs_response))
+        mock_run.return_value = mock_result
+
+        scanner.scan_sbom()
+        assert scanner.raw_result is not None
+
+        # Test process_result
+        scanner.process_result()
+        assert_vulnerability_processing_results(
+            scanner.processed_result, expected_cve_count=1, expected_cves=["CVE-2023-1234"]
+        )
+
+
+def test_result_processing_handles_missing_vulnerabilities_key_gracefully(rox_env, test_image):
+    """Test result processing handles missing 'vulnerabilities' key in raw result without errors."""
+    scanner = create_scanner_with_image(test_image)
+    scanner.raw_result = {"result": {}}  # Missing vulnerabilities key
+
+    scanner.process_result()
+
+    assert scanner.processed_result == {}
+
+
+def test_result_processing_handles_missing_result_key_gracefully(rox_env, test_image):
+    """Test result processing handles missing 'result' key in raw result without errors."""
+    scanner = create_scanner_with_image(test_image)
+    scanner.raw_result = {}  # Missing result key
+
+    scanner.process_result()
+
+    assert scanner.processed_result == {}
+
+
+def test_result_processing_filters_mixed_vulnerability_data_correctly(
+    rox_env, test_image, mixed_vulnerability_response
+):
+    """Test result processing correctly filters vulnerabilities with valid CVE IDs from mixed data set."""
+    scanner = create_scanner_with_image(test_image)
+    scanner.raw_result = mixed_vulnerability_response
+
+    scanner.process_result()
+
+    # Should only process vulnerabilities with valid CVE IDs
+    assert_vulnerability_processing_results(
+        scanner.processed_result,
+        expected_cve_count=2,
+        expected_cves=["CVE-2023-1234", "CVE-2023-5678"],
+    )
+
+    # Check package contents
+    assert_cve_packages_match(
+        scanner.processed_result, "CVE-2023-1234", [Package(name="package1", version="1.0.0")]
+    )
+
+    assert_cve_packages_match(
+        scanner.processed_result, "CVE-2023-5678", [Package(name="package4", version="4.0.0")]
+    )

--- a/src/tests/test_differ.py
+++ b/src/tests/test_differ.py
@@ -457,3 +457,33 @@ def test_integration_workflow():
     assert package_info["package1"]["previous_version"] == "1.0.0"
     assert package_info["package1"]["new_version"] == "1.1.0"
     assert package_info["package1"]["removed"] is False
+
+
+def test_init_with_invalid_scanner():
+    """Test VulnerabilityDiffer initialization with invalid scanner."""
+    with pytest.raises(
+        ValueError, match="Unsupported scanner: invalid. Supported scanners: \\['acs', 'trivy'\\]"
+    ):
+        VulnerabilityDiffer(
+            previous_sbom="/path/to/previous.json",
+            next_sbom="/path/to/next.json",
+            scanner="invalid",
+        )
+
+
+@patch.dict("os.environ", {"ROX_ENDPOINT": "https://localhost:8443", "ROX_API_TOKEN": "test-token"})
+def test_init_with_valid_scanners():
+    """Test VulnerabilityDiffer initialization with valid scanners."""
+    # Test with trivy scanner (default)
+    differ_trivy = VulnerabilityDiffer(
+        previous_sbom="/path/to/previous.json", next_sbom="/path/to/next.json", scanner="trivy"
+    )
+    assert differ_trivy.previous_release.sbom == "/path/to/previous.json"
+    assert differ_trivy.next_release.sbom == "/path/to/next.json"
+
+    # Test with acs scanner
+    differ_acs = VulnerabilityDiffer(
+        previous_sbom="/path/to/previous.json", next_sbom="/path/to/next.json", scanner="acs"
+    )
+    assert differ_acs.previous_release.sbom == "/path/to/previous.json"
+    assert differ_acs.next_release.sbom == "/path/to/next.json"


### PR DESCRIPTION
This commit introduces comprehensive support for Red Hat Advanced Cluster Security (ACS) as an alternative vulnerability scanner alongside the existing Trivy scanner.

Key changes:
- Add ACSScanner class implementing BaseScanner interface
- Support for ACS image scanning via roxctl CLI tool
- Add --scanner option to both image-diff and sbom-diff CLI commands
- Restrict sbom-diff to Trivy only (ACS doesn't support SBOM scanning)
- Integration with existing VulnerabilityDiffer workflow

The ACS scanner provides enterprise-grade vulnerability detection capabilities for container images, complementing the existing Trivy scanner options.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>
Assisted-by: Cursor, Claude