### PR TITLE
feat: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,49 @@
+name: Lint and Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox
+
+    - name: Run black
+      run: tox -e black
+
+    - name: Run flake8
+      run: tox -e flake8
+
+    - name: Run isort
+      run: tox -e isort
+
+    - name: Run mypy
+      run: tox -e mypy
+
+    - name: Run pytest
+      run: tox -e pytest
+
+    - name: Upload coverage to Codecov
+      if: matrix.python-version == '3.12'
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./coverage.xml
+        fail_ci_if_error: true


### PR DESCRIPTION
Add automated CI pipeline that runs on push to main and pull requests. Executes the same quality checks as tox: black, flake8, isort, mypy, and pytest. Includes coverage reporting to Codecov.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>
Assisted-by: Claude Code