### PR TITLE
feat: add automated release workflows and build testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,146 @@
+name: Release to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build-lib:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build twine
+
+    - name: Build library package
+      run: python -m build diffused/
+
+    - name: Check distribution
+      run: twine check diffused/dist/*
+
+    - name: Upload library artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: lib-dist
+        path: diffused/dist/
+
+  build-cli:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build twine
+
+    - name: Build CLI package
+      run: python -m build diffusedcli/
+
+    - name: Check distribution
+      run: twine check diffusedcli/dist/*
+
+    - name: Upload CLI artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: cli-dist
+        path: diffusedcli/dist/
+
+  test-lib:
+    runs-on: ubuntu-latest
+    needs: build-lib
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+
+    - name: Download library artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: lib-dist
+        path: diffused/dist/
+
+    - name: Install library package from dist
+      run: |
+        pip install diffused/dist/*.whl
+
+    - name: Test library installation
+      run: |
+        python -c "import diffused; print('Library imported successfully')"
+
+  test-cli:
+    runs-on: ubuntu-latest
+    needs: build-cli
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+
+    - name: Download CLI artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: cli-dist
+        path: diffusedcli/dist/
+
+    - name: Install CLI package from dist
+      run: |
+        pip install diffusedcli/dist/*.whl
+
+    - name: Test CLI installation
+      run: |
+        python -c "import diffusedcli; print('CLI imported successfully')"
+        diffused --help
+
+  publish-to-pypi:
+    runs-on: ubuntu-latest
+    needs: [test-lib, test-cli]
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download library artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: lib-dist
+        path: lib-dist/
+
+    - name: Download CLI artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: cli-dist
+        path: cli-dist/
+
+    - name: Publish library to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: lib-dist/
+
+    - name: Publish CLI to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: cli-dist/

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -1,0 +1,167 @@
+name: Release to Test PyPI
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-lib:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build twine
+
+    - name: Update library version with epoch time
+      run: |
+        EPOCH_TIME=$(date +%s)
+        sed -i 's/version = "\([0-9.]*\)"/version = "\1-dev'${EPOCH_TIME}'"/' diffused/pyproject.toml
+
+    - name: Build library package
+      run: python -m build diffused/
+
+    - name: Check distribution
+      run: twine check diffused/dist/*
+
+    - name: Upload library artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: lib-dist
+        path: diffused/dist/
+
+  build-cli:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build twine
+
+    - name: Update CLI version with epoch time
+      run: |
+        EPOCH_TIME=$(date +%s)
+        sed -i 's/version = "\([0-9.]*\)"/version = "\1-dev'${EPOCH_TIME}'"/' diffusedcli/pyproject.toml
+
+    - name: Build CLI package
+      run: python -m build diffusedcli/
+
+    - name: Check distribution
+      run: twine check diffusedcli/dist/*
+
+    - name: Upload CLI artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: cli-dist
+        path: diffusedcli/dist/
+
+  test-lib:
+    runs-on: ubuntu-latest
+    needs: build-lib
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+
+    - name: Download library artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: lib-dist
+        path: diffused/dist/
+
+    - name: Install library package from dist
+      run: |
+        pip install diffused/dist/*.whl
+
+    - name: Test library installation
+      run: |
+        python -c "import diffused; print('Library imported successfully')"
+
+  test-cli:
+    runs-on: ubuntu-latest
+    needs: [build-lib, build-cli]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+
+    - name: Download library artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: lib-dist
+        path: diffused/dist/
+
+    - name: Install library package from dist
+      run: |
+        pip install diffused/dist/*.whl
+
+    - name: Download CLI artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: cli-dist
+        path: diffusedcli/dist/
+
+    - name: Install CLI package from dist
+      run: |
+        pip install diffusedcli/dist/*.whl
+
+    - name: Test CLI installation
+      run: |
+        python -c "import diffusedcli; print('CLI imported successfully')"
+        diffused --help
+
+  publish-to-test-pypi:
+    runs-on: ubuntu-latest
+    needs: [test-lib, test-cli]
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download library artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: lib-dist
+        path: lib-dist/
+
+    - name: Download CLI artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: cli-dist
+        path: cli-dist/
+
+    - name: Publish library to Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        packages-dir: lib-dist/
+
+    - name: Publish CLI to Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        packages-dir: cli-dist/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,12 @@ jobs:
     - name: Run pytest-cli
       run: tox -e pytest-cli
 
+    - name: Run build-lib
+      run: tox -e build-lib
+
+    - name: Run build-cli
+      run: tox -e build-cli
+
     - name: Upload coverage to Codecov
       if: matrix.python-version == '3.12'
       uses: codecov/codecov-action@v5

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,28 +1,76 @@
 # Release Process
 
-This document describes how to release and publish the Diffused package to PyPI.
+This document describes how to release and publish the Diffused package to PyPI using automated GitHub Actions workflows.
 
-## Prerequisites
+## Automated Releases
 
-Install the required tools:
+The project uses GitHub Actions to automatically build and publish packages to PyPI:
 
-```bash
-pip install twine
-```
+### Test Releases (Test PyPI)
+- **Trigger**: Every push to the `main` branch
+- **Workflow**: `.github/workflows/test-release.yml`
+- **Packages**: Both library (`diffused-lib`) and CLI (`diffused-cli`)
+- **Versioning**: Automatically appends `-dev{COMMIT_HASH}` to the current version
+- **Repository**: Test PyPI (https://test.pypi.org/)
+
+### Production Releases (PyPI)
+- **Trigger**: Git tags matching `v*` pattern (e.g., `v1.0.0`) or manual dispatch
+- **Workflow**: `.github/workflows/release.yml`
+- **Packages**: Both library (`diffused-lib`) and CLI (`diffused-cli`)
+- **Versioning**: Uses the exact version from `pyproject.toml` files
+- **Repository**: Production PyPI (https://pypi.org/)
+
+## Creating a Release
+
+### For Production Release:
+
+1. **Update versions** in both `pyproject.toml` files:
+   - `diffused/pyproject.toml`
+   - `diffusedcli/pyproject.toml`
+
+2. **Create and push a git tag:**
+   ```bash
+   git tag v1.0.0
+   git push origin v1.0.0
+   ```
+
+3. **GitHub Actions will automatically:**
+   - Build both packages
+   - Test installations
+   - Publish to PyPI
+
+### Manual Workflow Dispatch
+You can also trigger releases manually from the GitHub Actions UI.
 
 ## Version Management
 
 Before creating a new release:
 
-1. **Update the version** in `pyproject.toml`:
+1. **Update the version** in both `pyproject.toml` files:
    ```toml
+   # diffused/pyproject.toml
    version = "0.1.1"  # Increment appropriately
+
+   # diffusedcli/pyproject.toml
+   version = "0.1.1"  # Keep in sync with library
    ```
 
 2. **Follow semantic versioning:**
    - **MAJOR**: Incompatible API changes
    - **MINOR**: Backward-compatible functionality additions
    - **PATCH**: Backward-compatible bug fixes
+
+## Manual Release (Fallback)
+
+If you need to publish manually (when automated workflows are not available):
+
+### Prerequisites
+
+Install the required tools:
+
+```bash
+pip install build twine
+```
 
 ## Publishing to PyPI
 
@@ -101,9 +149,18 @@ password = <your-test-token>
 
 ## Release Checklist
 
-- [ ] Update version in `pyproject.toml`
-- [ ] Clean previous builds (`rm -rf dist/ build/`)
-- [ ] Build package (`python -m build`)
+### For Automated Releases:
+- [ ] Update versions in both `diffused/pyproject.toml` and `diffusedcli/pyproject.toml`
+- [ ] Commit and push changes to main
+- [ ] Create and push git tag (e.g., `git tag v1.0.0 && git push origin v1.0.0`)
+- [ ] Monitor GitHub Actions workflow completion
+- [ ] Verify packages are published to PyPI
+- [ ] Test installation: `pip install diffused-cli`
+
+### For Manual Releases (Fallback):
+- [ ] Update versions in both `pyproject.toml` files
+- [ ] Clean previous builds (`rm -rf */dist/ */build/`)
+- [ ] Build packages (`python -m build diffused/` and `python -m build diffusedcli/`)
 - [ ] Test on Test PyPI
 - [ ] Verify installation and functionality
 - [ ] Publish to production PyPI

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ LIB_SOURCE = diffused/diffused
 LIB_TESTS = diffused/tests
 
 [tox]
-envlist = black, flake8, isort, mypy, pytest, pytest-cli
+envlist = black, flake8, isort, mypy, pytest, pytest-cli, build-lib, build-cli
 isolated_build = True
 
 [testenv]
@@ -56,3 +56,11 @@ commands =
         --cov-report=term-missing \
         --cov-fail-under 95 \
         {[vars]CLI_TESTS}
+
+[testenv:build-lib]
+deps = build
+commands = python -m build diffused/
+
+[testenv:build-cli]
+deps = build
+commands = python -m build diffusedcli/


### PR DESCRIPTION
Add GitHub Actions workflows for automated PyPI releases:
    - test-release.yml: publishes to Test PyPI on pushes to main with dev versions
    - release.yml: publishes to production PyPI on version tags
Update release documentation to reflect automated workflows.
Add tox build jobs (build-lib, build-cli) to verify package building
Update GitHub workflow to execute the build tests.
