### PR TITLE
Some refactors to the tests and command-line

### DIFF
--- a/diffused/tests/conftest.py
+++ b/diffused/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Shared fixtures for scanner tests."""
+"""Shared fixtures for all library tests."""
 
 from unittest.mock import patch
 
@@ -30,6 +30,30 @@ def test_sbom_path():
 def test_output_path():
     """Fixture to provide a consistent test output path."""
     return "/path/to/output.json"
+
+
+@pytest.fixture
+def test_previous_sbom_path():
+    """Fixture to provide a consistent test previous SBOM path."""
+    return "/path/to/previous.json"
+
+
+@pytest.fixture
+def test_next_sbom_path():
+    """Fixture to provide a consistent test next SBOM path."""
+    return "/path/to/next.json"
+
+
+@pytest.fixture
+def test_previous_image():
+    """Fixture to provide a consistent test previous image name."""
+    return "previous:latest"
+
+
+@pytest.fixture
+def test_next_image():
+    """Fixture to provide a consistent test next image name."""
+    return "next:latest"
 
 
 @pytest.fixture

--- a/diffused/tests/scanners/test_base.py
+++ b/diffused/tests/scanners/test_base.py
@@ -50,25 +50,25 @@ class SuperCallScanner(BaseScanner):
         return BaseScanner.get_version()
 
 
-def test_init_with_sbom():
+def test_init_with_sbom(test_sbom_path):
     """Test initialization with SBOM."""
-    scanner = ScannerClassTest(sbom="/path/to/sbom.json")
-    assert scanner.sbom == "/path/to/sbom.json"
+    scanner = ScannerClassTest(sbom=test_sbom_path)
+    assert scanner.sbom == test_sbom_path
     assert scanner.image is None
 
 
-def test_init_with_image():
+def test_init_with_image(test_image):
     """Test initialization with image."""
-    scanner = ScannerClassTest(image="test:latest")
-    assert scanner.image == "test:latest"
+    scanner = ScannerClassTest(image=test_image)
+    assert scanner.image == test_image
     assert scanner.sbom is None
 
 
-def test_init_with_both():
+def test_init_with_both(test_sbom_path, test_image):
     """Test initialization with both sbom and image."""
-    scanner = ScannerClassTest(sbom="/path/to/sbom.json", image="test:latest")
-    assert scanner.sbom == "/path/to/sbom.json"
-    assert scanner.image == "test:latest"
+    scanner = ScannerClassTest(sbom=test_sbom_path, image=test_image)
+    assert scanner.sbom == test_sbom_path
+    assert scanner.image == test_image
 
 
 def test_init_without_parameters_raises_error():
@@ -83,17 +83,17 @@ def test_init_with_empty_strings_raises_error():
         ScannerClassTest(sbom="", image="")
 
 
-def test_default_attributes():
+def test_default_attributes(test_sbom_path):
     """Test default attribute values."""
-    scanner = ScannerClassTest(sbom="/path/to/sbom.json")
+    scanner = ScannerClassTest(sbom=test_sbom_path)
     assert scanner.raw_result is None
     assert isinstance(scanner.processed_result, defaultdict)
     assert scanner.error == ""
 
 
-def test_processed_result_defaultdict_behavior():
+def test_processed_result_defaultdict_behavior(test_sbom_path):
     """Test processed_result creates sets automatically."""
-    scanner = ScannerClassTest(sbom="/path/to/sbom.json")
+    scanner = ScannerClassTest(sbom=test_sbom_path)
 
     # Accessing non-existent key creates empty set
     test_set = scanner.processed_result["CVE-2023-1234"]
@@ -101,9 +101,9 @@ def test_processed_result_defaultdict_behavior():
     assert len(test_set) == 0
 
 
-def test_processed_result_stores_packages():
+def test_processed_result_stores_packages(test_sbom_path):
     """Test processed_result can store Package objects."""
-    scanner = ScannerClassTest(sbom="/path/to/sbom.json")
+    scanner = ScannerClassTest(sbom=test_sbom_path)
 
     pkg = Package(name="test-package", version="1.0.0")
     scanner.processed_result["CVE-2023-1234"].add(pkg)
@@ -112,18 +112,18 @@ def test_processed_result_stores_packages():
     assert pkg in scanner.processed_result["CVE-2023-1234"]
 
 
-def test_cannot_instantiate_abstract_class():
+def test_cannot_instantiate_abstract_class(test_sbom_path):
     """Test BaseScanner cannot be instantiated directly."""
     with pytest.raises(TypeError):
-        BaseScanner(sbom="/path/to/sbom.json")
+        BaseScanner(sbom=test_sbom_path)
 
 
-def test_all_abstract_methods_implemented():
+def test_all_abstract_methods_implemented(test_sbom_path, test_output_path):
     """Test all abstract methods are implemented."""
-    scanner = ScannerClassTest(sbom="/path/to/sbom.json")
+    scanner = ScannerClassTest(sbom=test_sbom_path)
 
     # Should not raise NotImplementedError
-    scanner.retrieve_sbom("/path/to/output.json")
+    scanner.retrieve_sbom(test_output_path)
     scanner.scan_sbom()
     scanner.process_result()
     version = scanner.get_version()
@@ -131,7 +131,7 @@ def test_all_abstract_methods_implemented():
     assert version == "1.0.0"
 
 
-def test_abstract_methods_required():
+def test_abstract_methods_required(test_sbom_path):
     """Test that all abstract methods must be implemented."""
 
     class IncompleteScanner(BaseScanner):
@@ -141,26 +141,26 @@ def test_abstract_methods_required():
         # Missing other abstract methods
 
     with pytest.raises(TypeError):
-        IncompleteScanner(sbom="/path/to/sbom.json")
+        IncompleteScanner(sbom=test_sbom_path)
 
 
-def test_retrieve_sbom_not_implemented_error():
+def test_retrieve_sbom_not_implemented_error(test_sbom_path, test_output_path):
     """Test retrieve_sbom raises NotImplementedError when calling super."""
-    scanner = SuperCallScanner(sbom="/path/to/sbom.json")
+    scanner = SuperCallScanner(sbom=test_sbom_path)
     with pytest.raises(NotImplementedError):
-        scanner.retrieve_sbom("/path/to/output.json")
+        scanner.retrieve_sbom(test_output_path)
 
 
-def test_scan_sbom_not_implemented_error():
+def test_scan_sbom_not_implemented_error(test_sbom_path):
     """Test scan_sbom raises NotImplementedError when calling super."""
-    scanner = SuperCallScanner(sbom="/path/to/sbom.json")
+    scanner = SuperCallScanner(sbom=test_sbom_path)
     with pytest.raises(NotImplementedError):
         scanner.scan_sbom()
 
 
-def test_process_result_not_implemented_error():
+def test_process_result_not_implemented_error(test_sbom_path):
     """Test process_result raises NotImplementedError when calling super."""
-    scanner = SuperCallScanner(sbom="/path/to/sbom.json")
+    scanner = SuperCallScanner(sbom=test_sbom_path)
     with pytest.raises(NotImplementedError):
         scanner.process_result()
 
@@ -171,9 +171,9 @@ def test_get_version_not_implemented_error():
         SuperCallScanner.get_version()
 
 
-def test_error_attribute_assignment():
+def test_error_attribute_assignment(test_sbom_path):
     """Test error attribute can be set and retrieved."""
-    scanner = ScannerClassTest(sbom="/path/to/sbom.json")
+    scanner = ScannerClassTest(sbom=test_sbom_path)
 
     error_message = "Test error"
     scanner.error = error_message
@@ -181,9 +181,9 @@ def test_error_attribute_assignment():
     assert scanner.error == error_message
 
 
-def test_raw_result_assignment():
+def test_raw_result_assignment(test_sbom_path):
     """Test raw_result can be assigned."""
-    scanner = ScannerClassTest(sbom="/path/to/sbom.json")
+    scanner = ScannerClassTest(sbom=test_sbom_path)
 
     test_data = {"Results": []}
     scanner.raw_result = test_data

--- a/diffusedcli/README.md
+++ b/diffusedcli/README.md
@@ -42,6 +42,9 @@ pip install diffusedcli
 # Basic vulnerability diff between two container images
 diffused image-diff -p ubuntu:20.04 -n ubuntu:22.04
 
+# Use ACS scanner
+diffused --scanner acs image-diff -p nginx:1.20 -n nginx:1.21
+
 # Get detailed information about each vulnerability
 diffused image-diff -p nginx:1.20 -n nginx:1.21 --all-info
 
@@ -77,6 +80,7 @@ For more information on commands and options, use the `--help` option.
 
 | Option | Short | Description | Default |
 |--------|-------|-------------|---------|
+| `--scanner` | `-s` | Scanner to use (`acs`, `trivy`) | `trivy` |
 | `--all-info` | `-a` | Show detailed vulnerability information | `False` |
 | `--output` | `-o` | Output format (`rich`, `json`) | `rich` |
 | `--file` | `-f` | Output file (use `-` for stdout) | `-` |

--- a/diffusedcli/tests/conftest.py
+++ b/diffusedcli/tests/conftest.py
@@ -1,0 +1,53 @@
+"""Shared fixtures for CLI tests."""
+
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture
+def runner():
+    """Create a Click test runner."""
+    return CliRunner()
+
+
+@pytest.fixture
+def test_previous_sbom_path():
+    """Fixture to provide a consistent test previous SBOM path."""
+    return "/path/to/prev.json"
+
+
+@pytest.fixture
+def test_next_sbom_path():
+    """Fixture to provide a consistent test next SBOM path."""
+    return "/path/to/next.json"
+
+
+@pytest.fixture
+def test_previous_image():
+    """Fixture to provide a consistent test previous image name."""
+    return "prev:latest"
+
+
+@pytest.fixture
+def test_next_image():
+    """Fixture to provide a consistent test next image name."""
+    return "next:latest"
+
+
+@pytest.fixture
+def sample_vulnerabilities_list():
+    """Sample vulnerability list for testing."""
+    return ["CVE-2024-1234", "CVE-2024-5678", "CVE-2024-9999"]
+
+
+@pytest.fixture
+def sample_vulnerabilities_all_info():
+    """Sample vulnerability data with all info for testing."""
+    return {
+        "CVE-2024-1234": [
+            {"package1": {"previous_version": "1.0.0", "new_version": "1.1.0", "removed": False}}
+        ],
+        "CVE-2024-5678": [
+            {"package2": {"previous_version": "2.0.0", "new_version": "", "removed": True}}
+        ],
+    }

--- a/diffusedcli/tests/test_cli.py
+++ b/diffusedcli/tests/test_cli.py
@@ -414,13 +414,13 @@ def test_sbom_diff_with_trivy_scanner(
         result = runner.invoke(
             cli,
             [
+                "--scanner",
+                "trivy",
                 "sbom-diff",
                 "-p",
                 test_previous_sbom_path,
                 "-n",
                 test_next_sbom_path,
-                "--scanner",
-                "trivy",
             ],
         )
 
@@ -434,11 +434,11 @@ def test_sbom_diff_with_acs_scanner_error(runner, test_previous_sbom_path, test_
     """Test sbom-diff command fails when ACS scanner is used."""
     result = runner.invoke(
         cli,
-        ["sbom-diff", "-p", test_previous_sbom_path, "-n", test_next_sbom_path, "--scanner", "acs"],
+        ["--scanner", "acs", "sbom-diff", "-p", test_previous_sbom_path, "-n", test_next_sbom_path],
     )
 
-    assert result.exit_code == 2
-    assert "Invalid value for '-s' / '--scanner': 'acs' is not 'trivy'" in result.output
+    assert result.exit_code == 1
+    assert "Error: Only 'trivy' scanner is supported for SBOM scanning, got 'acs'" in result.output
 
 
 def test_sbom_diff_scanner_case_insensitive(runner, test_previous_sbom_path, test_next_sbom_path):
@@ -455,13 +455,13 @@ def test_sbom_diff_scanner_case_insensitive(runner, test_previous_sbom_path, tes
         result = runner.invoke(
             cli,
             [
+                "--scanner",
+                "TRIVY",
                 "sbom-diff",
                 "-p",
                 test_previous_sbom_path,
                 "-n",
                 test_next_sbom_path,
-                "--scanner",
-                "TRIVY",
             ],
         )
 
@@ -521,7 +521,7 @@ def test_image_diff_with_acs_scanner(
     mock_differ.return_value = mock_differ_instance
 
     result = runner.invoke(
-        cli, ["image-diff", "-p", test_previous_image, "-n", test_next_image, "--scanner", "acs"]
+        cli, ["--scanner", "acs", "image-diff", "-p", test_previous_image, "-n", test_next_image]
     )
 
     assert result.exit_code == 0
@@ -540,7 +540,7 @@ def test_image_diff_with_trivy_scanner(
     mock_differ.return_value = mock_differ_instance
 
     result = runner.invoke(
-        cli, ["image-diff", "-p", test_previous_image, "-n", test_next_image, "--scanner", "trivy"]
+        cli, ["--scanner", "trivy", "image-diff", "-p", test_previous_image, "-n", test_next_image]
     )
 
     assert result.exit_code == 0
@@ -553,7 +553,7 @@ def test_image_diff_invalid_scanner(runner, test_previous_image, test_next_image
     """Test image_diff command with invalid scanner."""
     result = runner.invoke(
         cli,
-        ["image-diff", "-p", test_previous_image, "-n", test_next_image, "--scanner", "invalid"],
+        ["--scanner", "invalid", "image-diff", "-p", test_previous_image, "-n", test_next_image],
     )
 
     assert result.exit_code != 0
@@ -573,7 +573,7 @@ def test_image_diff_scanner_case_insensitive(runner, test_previous_image, test_n
         # test uppercase ACS
         result = runner.invoke(
             cli,
-            ["image-diff", "-p", test_previous_image, "-n", test_next_image, "--scanner", "ACS"],
+            ["--scanner", "ACS", "image-diff", "-p", test_previous_image, "-n", test_next_image],
         )
 
         assert result.exit_code == 0


### PR DESCRIPTION
Move fixtures defined inside the tests to conftest and use them. This is already done for the ACS test.

The scanner option is defined in each command, but it is a general option. This moves the scanner option to the root command.