### PR TITLE
fix: install the library before installing the cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,16 @@ jobs:
       with:
         python-version: '3.12'
 
+    - name: Download library artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: lib-dist
+        path: diffused/dist/
+
+    - name: Install library package from dist
+      run: |
+        pip install diffused/dist/*.whl
+
     - name: Download CLI artifacts
       uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
This ensures that the library built is installed instead one from PyPi. We want to test the same library version as the cli.