### PR TITLE
chore: update codecov configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,11 +51,23 @@ jobs:
     - name: Run build-cli
       run: tox -e py39-build-cli
 
-    - name: Upload coverage to Codecov
+    - name: Upload library coverage to Codecov
       if: matrix.python-version == '3.9'
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: unit-tests
+        files: coverage.xml
+        fail_ci_if_error: false
+
+    - name: Upload CLI coverage to Codecov
+      if: matrix.python-version == '3.9'
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        flags: cli-tests
+        files: coverage-cli.xml
+        fail_ci_if_error: false
 
   commitlint:
     name: Conventional Commit Lint

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,17 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "50...100"
+
+flags:
+  unit-tests:
+    carryforward: true
+  cli-tests:
+    carryforward: true
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,7 @@ commands =
         --cov={[vars]CLI_SOURCE} \
         --cov-report=term-missing \
         --cov-fail-under 95 \
+        --cov-report xml:coverage-cli.xml \
         {[vars]CLI_TESTS}
 
 [testenv:py39-build-lib]


### PR DESCRIPTION
This updates the codecov configurations to the latest recommendations.

This also includes uploading the cli tests into codecov . If for some reason there weren't uploaded on purpose, let me know. I'll remove the change.