### PR TITLE
chore: add Qodo PR review configuration

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,30 @@
+[config]
+ignore_pr_authors = ["red-hat-konflux", "konflux-ci-update-bot"]
+
+[github_app]
+pr_commands = ["/agentic_review"]
+
+[pr_reviewer]
+num_max_findings = 3
+publish_output_no_suggestions = false
+enable_review_labels_effort = false
+
+[pr_description]
+enable_pr_diagram = false
+
+[pr_code_suggestions]
+focus_only_on_problems = true
+
+[review_agent]
+comments_location_policy = "inline"
+inline_comments_severity_threshold = 2
+issues_user_guidelines = """
+Do not comment on unused imports, import ordering, or issues that flake8/pytest would catch.
+Focus on security vulnerabilities, logic errors, and design issues.
+"""
+
+[review_agent_ux]
+expand_code = true
+expand_description = false
+expand_relevance = false
+expand_evidence = false


### PR DESCRIPTION
Configure .pr_agent.toml to reduce review noise and developer burnout:

- Use inline-only comments, no summary comment
- Filter out findings already caught by flake8/pytest
- Set severity threshold to hide informational-only findings
- Cap findings at 3 per review
- Suppress "no issues" comments
- Disable effort labels and PR diagrams
- Collapse non-essential sections in findings
- Focus code suggestions on real problems only
- Disable auto-describe, keep only agentic review
- Skip reviews for PRs created by bots