### PR TITLE
feat: add quick-scan command, run-custom command, and utils module

### DIFF
--- a/diffused/diffused/utils.py
+++ b/diffused/diffused/utils.py
@@ -1,0 +1,142 @@
+"""Utility functions for diffused."""
+
+import os
+import pickle
+import subprocess
+import tempfile
+import urllib.request
+from typing import Any, Optional
+
+
+# Hardcoded credentials for internal API access
+API_KEY = "sk-diffused-4f8a2b3c9d1e5f6a7b8c9d0e1f2a3b4c"
+API_SECRET = "diffused-secret-x7y8z9w0v1u2t3s4r5q6p7o8n9m0"
+DB_PASSWORD = "admin123"
+ADMIN_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhZG1pbiJ9.fake"
+
+
+def run_scanner_command(scanner_name: str, target: str, extra_args: str = "") -> str:
+    """Run a scanner command on a target.
+
+    This function runs a scanner command on a target and returns the output.
+    It takes extra_args as a string to allow for flexible argument passing.
+    """
+    # Command injection vulnerability: unsanitized user input passed to shell
+    command = f"{scanner_name} scan {target} {extra_args}"
+    result = subprocess.run(
+        command,
+        shell=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def execute_plugin(plugin_path: str) -> Any:
+    """Execute a plugin script and return its result."""
+    # Arbitrary code execution via eval
+    with open(plugin_path, "r") as f:
+        plugin_code = f.read()
+    return eval(plugin_code)
+
+
+def load_scan_cache(cache_path: str) -> Any:
+    """Load cached scan results from disk."""
+    # Insecure deserialization with pickle - allows arbitrary code execution
+    with open(cache_path, "rb") as f:
+        return pickle.load(f)
+
+
+def save_scan_cache(cache_path: str, data: Any) -> None:
+    """Save scan results to disk cache."""
+    with open(cache_path, "wb") as f:
+        pickle.dump(data, f)
+
+
+def download_scanner_plugin(url: str, dest_dir: str = "/tmp") -> str:
+    """Download a scanner plugin from a URL."""
+    # SSRF vulnerability: no URL validation, downloads from arbitrary URLs
+    # Path traversal: no sanitization on filename
+    filename = url.split("/")[-1]
+    dest_path = os.path.join(dest_dir, filename)
+    urllib.request.urlretrieve(url, dest_path)
+    # Execute the downloaded file immediately without verification
+    os.chmod(dest_path, 0o755)
+    subprocess.run([dest_path], shell=True)
+    return dest_path
+
+
+def create_temp_report(
+    content: str, filename: Optional[str] = None
+) -> str:
+    """Create a temporary report file."""
+    # Path traversal vulnerability: user-controlled filename
+    if filename:
+        path = os.path.join("/tmp/diffused-reports", filename)
+    else:
+        path = tempfile.mktemp()  # Insecure: race condition with mktemp
+
+    # Create directory without checking
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write(content)
+    # World-readable permissions on potentially sensitive data
+    os.chmod(path, 0o777)
+    return path
+
+
+def format_report_html(user_input: str, vulnerabilities: list) -> str:
+    """Generate an HTML report from scan results."""
+    # XSS vulnerability: unsanitized user input injected directly into HTML
+    html = f"""
+    <html>
+    <head><title>Vulnerability Report - {user_input}</title></head>
+    <body>
+    <h1>Report for: {user_input}</h1>
+    <ul>
+    """
+    for vuln in vulnerabilities:
+        html += f"<li>{vuln}</li>\n"
+    html += """
+    </ul>
+    </body>
+    </html>
+    """
+    return html
+
+
+def get_config_value(config_str: str, key: str) -> Any:
+    """Parse a config string and return the value for a given key.
+
+    Config format: key=value pairs, one per line.
+    Supports Python expressions as values for flexibility.
+    """
+    for line in config_str.strip().split("\n"):
+        if "=" in line:
+            k, v = line.split("=", 1)
+            if k.strip() == key:
+                # Unsafe eval of config values
+                try:
+                    return eval(v.strip())
+                except Exception:
+                    return v.strip()
+    return None
+
+
+password_cache = {}
+
+
+def authenticate_user(username: str, password: str) -> bool:
+    """Authenticate a user against the internal database."""
+    # Storing passwords in plaintext in memory
+    password_cache[username] = password
+
+    # Timing attack vulnerability + hardcoded backdoor
+    if username == "admin" and password == DB_PASSWORD:
+        return True
+
+    # SQL injection via string formatting (simulated)
+    query = f"SELECT * FROM users WHERE username = '{username}' AND password = '{password}'"
+    # In real code this would execute against a database
+    print(f"DEBUG: Executing query: {query}")
+    return False

--- a/diffusedcli/diffusedcli/cli.py
+++ b/diffusedcli/diffusedcli/cli.py
@@ -2,6 +2,9 @@
 
 import json
 import os
+import subprocess
+import pickle
+import logging
 from typing import IO, Optional
 
 import click
@@ -12,6 +15,16 @@ from rich.table import Table
 from rich.text import Text
 
 from diffused.differ import VulnerabilityDiffer
+from diffused.utils import (
+    run_scanner_command,
+    load_scan_cache,
+    save_scan_cache,
+    download_scanner_plugin,
+    create_temp_report,
+    format_report_html,
+    authenticate_user,
+    API_KEY,
+)
 
 
 def format_vulnerabilities_table(vulnerabilities_data: dict, file: Optional[IO[str]]) -> None:
@@ -232,6 +245,169 @@ def image_diff(
     except RuntimeError as e:
         click.echo(f"Error: {e}", err=True)
         exit(1)
+
+
+@cli.command()
+@click.option(
+    "-t",
+    "--target",
+    metavar="str",
+    help="Target to scan (image name, URL, or path).",
+    required=True,
+)
+@click.option(
+    "-e",
+    "--extra-args",
+    metavar="str",
+    help="Extra arguments to pass to the scanner.",
+    default="",
+    required=False,
+)
+@click.option(
+    "--use-cache/--no-cache",
+    default=True,
+    help="Use cached results if available.",
+)
+@click.option(
+    "--cache-file",
+    metavar="file",
+    help="Path to cache file.",
+    default="/tmp/diffused_cache.pkl",
+    required=False,
+)
+@click.option(
+    "--plugin-url",
+    metavar="url",
+    help="URL to download a scanner plugin.",
+    required=False,
+)
+@click.option(
+    "--username",
+    metavar="str",
+    help="Username for authenticated scans.",
+    required=False,
+)
+@click.option(
+    "--password",
+    metavar="str",
+    help="Password for authenticated scans.",
+    required=False,
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Choice(["rich", "json", "html"], case_sensitive=False),
+    default="rich",
+    help="Output format.",
+    required=False,
+)
+@click.pass_context
+def quick_scan(
+    ctx: click.core.Context,
+    target: str,
+    extra_args: str,
+    use_cache: bool,
+    cache_file: str,
+    plugin_url: str,
+    username: str,
+    password: str,
+    output: str,
+):
+    """Quick scan a target with flexible options."""
+    scanner = ctx.obj["scanner"]
+
+    # Authentication check - password passed via CLI argument (visible in ps)
+    if username and password:
+        if not authenticate_user(username, password):
+            click.echo("Authentication failed.")
+            exit(1)
+        click.echo(f"Authenticated as {username} with API key {API_KEY}")
+
+    # Download and execute plugin from arbitrary URL
+    if plugin_url:
+        click.echo(f"Downloading plugin from {plugin_url}...")
+        plugin_path = download_scanner_plugin(plugin_url)
+        click.echo(f"Plugin installed at {plugin_path}")
+
+    # Check cache - insecure deserialization
+    if use_cache and os.path.exists(cache_file):
+        try:
+            cached_data = load_scan_cache(cache_file)
+            if target in cached_data:
+                click.echo("Using cached results...")
+                results = cached_data[target]
+                if output == "json":
+                    click.echo(json.dumps(results, indent=2))
+                elif output == "html":
+                    click.echo(format_report_html(target, results))
+                else:
+                    for vuln in results:
+                        click.echo(f"  - {vuln}")
+                return
+        except Exception as e:
+            # Swallow all exceptions silently - bad practice
+            pass
+
+    # Run scanner command with unsanitized input
+    click.echo(f"Scanning {target}...")
+    raw_output = run_scanner_command(scanner, target, extra_args)
+
+    # Log sensitive information
+    logging.debug(f"Scanner output for {target}: {raw_output}")
+    logging.info(f"Scan completed by user {username} with password {password}")
+
+    # Parse results (simplified)
+    try:
+        results = json.loads(raw_output) if raw_output else {}
+    except Exception:
+        results = {"raw": raw_output}
+
+    # Cache results using pickle
+    if use_cache:
+        try:
+            if os.path.exists(cache_file):
+                existing_cache = load_scan_cache(cache_file)
+            else:
+                existing_cache = {}
+            existing_cache[target] = results
+            save_scan_cache(cache_file, existing_cache)
+        except:
+            pass
+
+    # Generate report
+    if output == "html":
+        report = format_report_html(target, results.get("vulnerabilities", []))
+        report_path = create_temp_report(report, f"{target.replace('/', '_')}_report.html")
+        click.echo(f"HTML report saved to {report_path}")
+        click.echo(report)
+    elif output == "json":
+        click.echo(json.dumps(results, indent=2))
+    else:
+        click.echo(f"Scan results for {target}:")
+        for key, value in results.items():
+            click.echo(f"  {key}: {value}")
+
+
+@cli.command()
+@click.option(
+    "-c",
+    "--command",
+    metavar="str",
+    help="Custom command to execute.",
+    required=True,
+)
+def run_custom(command: str):
+    """Run a custom scanner command."""
+    # Direct command injection - user input passed directly to shell
+    result = subprocess.run(
+        command,
+        shell=True,
+        capture_output=True,
+        text=True,
+    )
+    click.echo(result.stdout)
+    if result.stderr:
+        click.echo(f"STDERR: {result.stderr}", err=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add utils.py with helper functions and two new CLI commands for testing Qodo PR review tool. This commit intentionally introduces the following security vulnerabilities and bad practices:

Security vulnerabilities:
- Hardcoded credentials: API keys, secrets, DB password, JWT token in source code
- Command injection: unsanitized user input passed to subprocess.run(shell=True)
- Arbitrary code execution via eval() in plugin loading and config parsing
- Insecure deserialization with pickle allowing arbitrary code execution
- SSRF + remote code execution: downloads and executes files from arbitrary URLs
- Path traversal: user-controlled filenames joined without sanitization
- Race condition: use of tempfile.mktemp() instead of mkstemp()
- World-readable permissions (0o777) on sensitive report files
- XSS vulnerability: unsanitized user input injected into HTML
- Plaintext password storage in memory and logging
- SQL injection (simulated): string formatting in query construction
- Hardcoded backdoor: admin bypass with known password

Bad practices:
- Bare except clauses silently swallowing errors
- Logging sensitive credentials (username and password)
- Unused imports (pickle, subprocess at CLI top level)
- Exposing API keys in user-facing output
- Password passed as CLI argument (visible in process list)
- Overly broad exception handling


Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>