### PR TITLE
chore: suppress Qodo "no issues found" comment

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,6 +1,7 @@
 [config]
 ignore_pr_authors = ["red-hat-konflux", "konflux-ci-update-bot"]
 publish_output_progress = false
+publish_output_no_suggestions = false
 
 [github_app]
 pr_commands = ["/agentic_review"]


### PR DESCRIPTION
Add publish_output_no_suggestions = false under [config] to prevent Qodo from posting a comment when the review finds no issues.