### PR TITLE
feat: add Grype vulnerability scanner support

### DIFF
--- a/diffused/diffused/differ.py
+++ b/diffused/diffused/differ.py
@@ -5,6 +5,7 @@ import logging
 from typing import Dict, List, Optional, Union
 
 from diffused.scanners.acs import ACSScanner
+from diffused.scanners.grype import GrypeScanner
 from diffused.scanners.trivy import TrivyScanner
 
 logger = logging.getLogger(__name__)
@@ -38,6 +39,7 @@ class VulnerabilityDiffer:
         """Get the scanner class based on the scanner name."""
         scanner_map = {
             "acs": ACSScanner,
+            "grype": GrypeScanner,
             "trivy": TrivyScanner,
         }
 

--- a/diffused/diffused/scanners/grype.py
+++ b/diffused/diffused/scanners/grype.py
@@ -1,0 +1,157 @@
+"""Grype scanner implementation."""
+
+import json
+import logging
+import subprocess
+
+from diffused.scanners.base import BaseScanner
+from diffused.scanners.models import Package
+
+logger = logging.getLogger(__name__)
+
+
+class GrypeScanner(BaseScanner):
+    """Grype scanner class."""
+
+    def _run_grype_command(self, cmd: list[str], operation: str) -> subprocess.CompletedProcess:
+        """Helper method to run Grype commands."""
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                shell=False,
+                text=True,
+                timeout=120,
+            )
+            result.check_returncode()
+            return result
+        except subprocess.CalledProcessError as e:
+            error_message = f"Grype {operation} failed. Return code: {e.returncode}."
+            if e.stderr:
+                error_message += f" Error output: {e.stderr}"
+            logger.error(error_message)
+            self.error = error_message
+            raise
+        except subprocess.TimeoutExpired:
+            error_message = f"Grype {operation} timed out."
+            logger.error(error_message)
+            self.error = error_message
+            raise
+        except Exception as e:
+            error_message = f"Unexpected error during Grype {operation}: {e}."
+            logger.error(error_message)
+            self.error = error_message
+            raise
+
+    def scan_sbom(self) -> None:
+        """Performs a scan on a given SBOM."""
+        if not self.sbom:
+            raise ValueError(
+                "You must set the SBOM path or retrieve from a container image before scanning it."
+            )
+
+        cmd = [
+            "grype",
+            f"sbom:{self.sbom}",
+            "-o",
+            "json",
+        ]
+
+        try:
+            result = self._run_grype_command(cmd, f"SBOM scan for {self.sbom}")
+            self.raw_result = json.loads(result.stdout)
+            logger.info("Successfully scanned SBOM %s", self.sbom)
+        except json.JSONDecodeError as e:
+            error_message = f"Error parsing Grype output for {self.sbom}: {e}."
+            logger.error(error_message)
+            self.error = error_message
+        except Exception:
+            pass
+
+    def scan_image(self) -> None:
+        """Performs a scan on a given image."""
+        if not self.image:
+            raise ValueError("You must set the image to scan.")
+
+        cmd = [
+            "grype",
+            self.image,
+            "-o",
+            "json",
+        ]
+
+        try:
+            result = self._run_grype_command(cmd, f"Image scan for {self.image}")
+            self.raw_result = json.loads(result.stdout)
+            logger.info("Successfully scanned image %s", self.image)
+        except json.JSONDecodeError as e:
+            error_message = f"Error parsing Grype output for {self.image}: {e}."
+            logger.error(error_message)
+            self.error = error_message
+        except Exception:
+            pass
+
+    def process_result(self) -> None:
+        """Processes the desired data from the given scan result."""
+        if self.raw_result is None:
+            raise ValueError("Run a scan before processing its output.")
+
+        self.processed_result.clear()
+
+        matches = self.raw_result.get("matches")
+        if not matches:
+            logger.info("No vulnerabilities found in scan results.")
+            return
+
+        vulnerability_count = 0
+        skipped_count = 0
+
+        for match in matches:
+            vulnerability = match.get("vulnerability", {})
+            vulnerability_id = vulnerability.get("id")
+            if not vulnerability_id:
+                skipped_count += 1
+                continue
+
+            artifact = match.get("artifact", {})
+            pkg_info = Package(name=artifact.get("name", ""), version=artifact.get("version", ""))
+
+            if vulnerability_id not in self.processed_result:
+                self.processed_result[vulnerability_id] = set()
+            self.processed_result[vulnerability_id].add(pkg_info)
+            vulnerability_count += 1
+
+        unique_vulnerabilities = len(self.processed_result)
+        if unique_vulnerabilities == 0:
+            logger.info("No vulnerabilities found in any match.")
+        else:
+            logger.info(
+                "Processed %d vulnerabilities into %d unique vulnerability IDs.",
+                vulnerability_count,
+                unique_vulnerabilities,
+            )
+            if skipped_count > 0:
+                logger.warning("Skipped %d vulnerabilities without IDs.", skipped_count)
+
+    @staticmethod
+    def get_version() -> str:
+        """Returns Grype scanner version."""
+        try:
+            result = subprocess.run(
+                ["grype", "version"], capture_output=True, shell=False, text=True, timeout=10
+            )
+            result.check_returncode()
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+            error_message = f"Failed to get Grype version: {str(e)}"
+            logger.error(error_message)
+            return "unknown"
+        except Exception as e:
+            error_message = f"Unexpected error during Grype version check: {e}."
+            logger.error(error_message)
+            return "unknown"
+
+        for line in result.stdout.strip().split("\n"):
+            if line.startswith("Version:"):
+                return line.split("Version:")[1].strip()
+
+        return "unknown"

--- a/diffused/tests/scanners/test_grype.py
+++ b/diffused/tests/scanners/test_grype.py
@@ -1,0 +1,414 @@
+"""Unit tests for GrypeScanner class."""
+
+import json
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from diffused.scanners.grype import GrypeScanner
+from diffused.scanners.models import Package
+
+
+def test_init_with_image(test_image):
+    """Test GrypeScanner initialization with image."""
+    scanner = GrypeScanner(image=test_image)
+    assert scanner.image == test_image
+    assert scanner.sbom is None
+    assert scanner.raw_result is None
+    assert scanner.processed_result == {}
+    assert scanner.error == ""
+
+
+def test_init_with_sbom(test_sbom_path):
+    """Test GrypeScanner initialization with SBOM."""
+    scanner = GrypeScanner(sbom=test_sbom_path)
+    assert scanner.sbom == test_sbom_path
+    assert scanner.image is None
+    assert scanner.raw_result is None
+    assert scanner.processed_result == {}
+    assert scanner.error == ""
+
+
+def test_init_with_both(test_image, test_sbom_path):
+    """Test GrypeScanner initialization with both image and SBOM."""
+    scanner = GrypeScanner(image=test_image, sbom=test_sbom_path)
+    assert scanner.image == test_image
+    assert scanner.sbom == test_sbom_path
+
+
+def test_init_with_neither_raises_error():
+    """Test GrypeScanner initialization fails without image or SBOM."""
+    with pytest.raises(ValueError, match="You must set sbom or image"):
+        GrypeScanner()
+
+
+@patch("diffused.scanners.grype.subprocess.run")
+def test_run_grype_command_success(mock_run, test_image):
+    """Test successful _run_grype_command execution."""
+    scanner = GrypeScanner(image=test_image)
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_run.return_value = mock_result
+
+    result = scanner._run_grype_command(["grype", "version"], "test operation")
+
+    mock_run.assert_called_once_with(
+        ["grype", "version"], capture_output=True, shell=False, text=True, timeout=120
+    )
+    assert result == mock_result
+
+
+@patch("diffused.scanners.grype.subprocess.run")
+def test_run_grype_command_called_process_error(mock_run, test_image):
+    """Test _run_grype_command with CalledProcessError."""
+    scanner = GrypeScanner(image=test_image)
+    mock_run.side_effect = subprocess.CalledProcessError(1, ["grype"], stderr="error output")
+
+    with pytest.raises(subprocess.CalledProcessError):
+        scanner._run_grype_command(["grype", "version"], "test operation")
+
+    assert "Grype test operation failed" in scanner.error
+    assert "error output" in scanner.error
+
+
+@patch("diffused.scanners.grype.subprocess.run")
+def test_run_grype_command_timeout(mock_run, test_image):
+    """Test _run_grype_command with timeout."""
+    scanner = GrypeScanner(image=test_image)
+    mock_run.side_effect = subprocess.TimeoutExpired(["grype"], 120)
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        scanner._run_grype_command(["grype", "version"], "test operation")
+
+    assert "Grype test operation timed out" in scanner.error
+
+
+@patch("diffused.scanners.grype.subprocess.run")
+def test_run_grype_command_unexpected_error(mock_run, test_image):
+    """Test _run_grype_command with unexpected error."""
+    scanner = GrypeScanner(image=test_image)
+    mock_run.side_effect = Exception("Unexpected error")
+
+    with pytest.raises(Exception):
+        scanner._run_grype_command(["grype", "version"], "test operation")
+
+    assert "Unexpected error during Grype test operation" in scanner.error
+
+
+@patch.object(GrypeScanner, "_run_grype_command")
+def test_scan_sbom_success(mock_run_command, test_sbom_path):
+    """Test successful SBOM scan."""
+    scanner = GrypeScanner(sbom=test_sbom_path)
+    mock_result = MagicMock()
+    mock_result.stdout = '{"matches": []}'
+    mock_run_command.return_value = mock_result
+
+    scanner.scan_sbom()
+
+    mock_run_command.assert_called_once_with(
+        ["grype", f"sbom:{test_sbom_path}", "-o", "json"],
+        f"SBOM scan for {test_sbom_path}",
+    )
+    assert scanner.raw_result == {"matches": []}
+
+
+def test_scan_sbom_no_sbom(test_image):
+    """Test scan_sbom fails without SBOM."""
+    scanner = GrypeScanner(image=test_image)
+    with pytest.raises(
+        ValueError, match="You must set the SBOM path or retrieve from a container image"
+    ):
+        scanner.scan_sbom()
+
+
+@patch.object(GrypeScanner, "_run_grype_command")
+def test_scan_sbom_json_decode_error(mock_run_command, test_sbom_path):
+    """Test scan_sbom handles JSON decode error."""
+    scanner = GrypeScanner(sbom=test_sbom_path)
+    mock_result = MagicMock()
+    mock_result.stdout = "invalid json"
+    mock_run_command.return_value = mock_result
+
+    scanner.scan_sbom()
+
+    assert "Error parsing Grype output" in scanner.error
+    assert scanner.raw_result is None
+
+
+@patch.object(GrypeScanner, "_run_grype_command")
+def test_scan_sbom_command_failure(mock_run_command, test_sbom_path):
+    """Test scan_sbom handles command failure."""
+    scanner = GrypeScanner(sbom=test_sbom_path)
+    mock_run_command.side_effect = subprocess.CalledProcessError(1, ["grype"])
+
+    scanner.scan_sbom()
+
+    assert scanner.raw_result is None
+
+
+@patch.object(GrypeScanner, "_run_grype_command")
+def test_scan_image_success(mock_run_command, test_image):
+    """Test successful image scan."""
+    scanner = GrypeScanner(image=test_image)
+    mock_result = MagicMock()
+    mock_result.stdout = json.dumps(
+        {
+            "matches": [
+                {
+                    "vulnerability": {"id": "CVE-2023-1234"},
+                    "artifact": {"name": "package1", "version": "1.0.0"},
+                }
+            ]
+        }
+    )
+    mock_run_command.return_value = mock_result
+
+    scanner.scan_image()
+
+    mock_run_command.assert_called_once_with(
+        ["grype", test_image, "-o", "json"],
+        f"Image scan for {test_image}",
+    )
+    assert scanner.raw_result is not None
+    assert "matches" in scanner.raw_result
+    assert len(scanner.raw_result["matches"]) == 1
+    assert scanner.error == ""
+
+
+def test_scan_image_no_image(test_sbom_path):
+    """Test scan_image fails without image."""
+    scanner = GrypeScanner(sbom=test_sbom_path)
+    with pytest.raises(ValueError, match="You must set the image to scan"):
+        scanner.scan_image()
+
+
+@patch.object(GrypeScanner, "_run_grype_command")
+def test_scan_image_json_decode_error(mock_run_command, test_image):
+    """Test scan_image handles JSON decode error."""
+    scanner = GrypeScanner(image=test_image)
+    mock_result = MagicMock()
+    mock_result.stdout = "invalid json"
+    mock_run_command.return_value = mock_result
+
+    scanner.scan_image()
+
+    assert "Error parsing Grype output" in scanner.error
+    assert scanner.raw_result is None
+
+
+@patch.object(GrypeScanner, "_run_grype_command")
+def test_scan_image_command_failure(mock_run_command, test_image):
+    """Test scan_image handles command failure."""
+    scanner = GrypeScanner(image=test_image)
+    mock_run_command.side_effect = subprocess.CalledProcessError(1, ["grype"])
+
+    scanner.scan_image()
+
+    assert scanner.raw_result is None
+
+
+def test_process_result_no_raw_result(test_image):
+    """Test process_result fails without raw result."""
+    scanner = GrypeScanner(image=test_image)
+    with pytest.raises(ValueError, match="Run a scan before processing its output"):
+        scanner.process_result()
+
+
+def test_process_result_no_matches(test_image):
+    """Test process_result with no matches in raw_result."""
+    scanner = GrypeScanner(image=test_image)
+    scanner.raw_result = {}
+
+    scanner.process_result()
+
+    assert scanner.processed_result == {}
+
+
+def test_process_result_empty_matches(test_image):
+    """Test process_result with empty matches array."""
+    scanner = GrypeScanner(image=test_image)
+    scanner.raw_result = {"matches": []}
+
+    scanner.process_result()
+
+    assert scanner.processed_result == {}
+
+
+def test_process_result_with_vulnerabilities(test_image):
+    """Test process_result with vulnerabilities."""
+    scanner = GrypeScanner(image=test_image)
+    scanner.raw_result = {
+        "matches": [
+            {
+                "vulnerability": {"id": "CVE-2023-1234"},
+                "artifact": {"name": "package1", "version": "1.0.0"},
+            },
+            {
+                "vulnerability": {"id": "CVE-2023-5678"},
+                "artifact": {"name": "package2", "version": "2.0.0"},
+            },
+            {
+                "vulnerability": {"id": "CVE-2023-1234"},
+                "artifact": {"name": "package3", "version": "1.5.0"},
+            },
+        ]
+    }
+
+    scanner.process_result()
+
+    assert len(scanner.processed_result) == 2
+    assert "CVE-2023-1234" in scanner.processed_result
+    assert "CVE-2023-5678" in scanner.processed_result
+
+    cve_1234_packages = scanner.processed_result["CVE-2023-1234"]
+    assert len(cve_1234_packages) == 2
+    assert Package(name="package1", version="1.0.0") in cve_1234_packages
+    assert Package(name="package3", version="1.5.0") in cve_1234_packages
+
+    cve_5678_packages = scanner.processed_result["CVE-2023-5678"]
+    assert len(cve_5678_packages) == 1
+    assert Package(name="package2", version="2.0.0") in cve_5678_packages
+
+
+def test_process_result_all_vulnerabilities_skipped(test_image):
+    """Test process_result when all matches lack vulnerability IDs."""
+    scanner = GrypeScanner(image=test_image)
+    scanner.raw_result = {
+        "matches": [
+            {
+                "vulnerability": {},
+                "artifact": {"name": "package1", "version": "1.0.0"},
+            },
+            {
+                "vulnerability": {},
+                "artifact": {"name": "package2", "version": "2.0.0"},
+            },
+        ]
+    }
+
+    scanner.process_result()
+
+    assert scanner.processed_result == {}
+
+
+def test_process_result_skip_vulnerabilities_without_id(test_image):
+    """Test process_result skips vulnerabilities without ID."""
+    scanner = GrypeScanner(image=test_image)
+    scanner.raw_result = {
+        "matches": [
+            {
+                "vulnerability": {"id": "CVE-2023-1234"},
+                "artifact": {"name": "package1", "version": "1.0.0"},
+            },
+            {
+                "vulnerability": {},
+                "artifact": {"name": "package2", "version": "2.0.0"},
+            },
+        ]
+    }
+
+    scanner.process_result()
+
+    assert len(scanner.processed_result) == 1
+    assert "CVE-2023-1234" in scanner.processed_result
+
+
+def test_process_result_clears_previous_results(test_image):
+    """Test process_result clears previous results."""
+    scanner = GrypeScanner(image=test_image)
+    scanner.processed_result["CVE-2023-OLD"] = {Package(name="old", version="1.0.0")}
+    scanner.raw_result = {"matches": []}
+
+    scanner.process_result()
+
+    assert scanner.processed_result == {}
+
+
+@patch("diffused.scanners.grype.subprocess.run")
+def test_get_version_success(mock_run):
+    """Test successful get_version."""
+    mock_result = MagicMock()
+    mock_result.stdout = (
+        "Application:         grype\n"
+        "Version:             0.112.0\n"
+        "BuildDate:           2026-05-01T18:57:12Z\n"
+    )
+    mock_result.returncode = 0
+    mock_run.return_value = mock_result
+
+    version = GrypeScanner.get_version()
+
+    mock_run.assert_called_once_with(
+        ["grype", "version"], capture_output=True, shell=False, text=True, timeout=10
+    )
+    assert version == "0.112.0"
+
+
+@patch("diffused.scanners.grype.subprocess.run")
+def test_get_version_called_process_error(mock_run):
+    """Test get_version with CalledProcessError."""
+    mock_run.side_effect = subprocess.CalledProcessError(1, ["grype"])
+
+    version = GrypeScanner.get_version()
+
+    assert version == "unknown"
+
+
+@patch("diffused.scanners.grype.subprocess.run")
+def test_get_version_timeout(mock_run):
+    """Test get_version with timeout."""
+    mock_run.side_effect = subprocess.TimeoutExpired(["grype"], 10)
+
+    version = GrypeScanner.get_version()
+
+    assert version == "unknown"
+
+
+@patch("diffused.scanners.grype.subprocess.run")
+def test_get_version_unexpected_error(mock_run):
+    """Test get_version with unexpected error."""
+    mock_run.side_effect = Exception("Unexpected error")
+
+    version = GrypeScanner.get_version()
+
+    assert version == "unknown"
+
+
+@patch("diffused.scanners.grype.subprocess.run")
+def test_get_version_malformed_output(mock_run):
+    """Test get_version with malformed output."""
+    mock_result = MagicMock()
+    mock_result.stdout = "Invalid output format\n"
+    mock_result.returncode = 0
+    mock_run.return_value = mock_result
+
+    version = GrypeScanner.get_version()
+
+    assert version == "unknown"
+
+
+def test_integration_workflow(test_image):
+    """Test complete workflow integration."""
+    scanner = GrypeScanner(image=test_image)
+
+    with patch.object(scanner, "_run_grype_command") as mock_run:
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps(
+            {
+                "matches": [
+                    {
+                        "vulnerability": {"id": "CVE-2023-1234"},
+                        "artifact": {"name": "package1", "version": "1.0.0"},
+                    }
+                ]
+            }
+        )
+        mock_run.return_value = mock_result
+
+        scanner.scan_image()
+        assert scanner.raw_result is not None
+
+        scanner.process_result()
+        assert len(scanner.processed_result) == 1
+        assert "CVE-2023-1234" in scanner.processed_result

--- a/diffused/tests/test_differ.py
+++ b/diffused/tests/test_differ.py
@@ -431,7 +431,8 @@ def test_integration_workflow(test_previous_sbom_path, test_next_sbom_path):
 def test_init_with_invalid_scanner(test_previous_sbom_path, test_next_sbom_path):
     """Test VulnerabilityDiffer initialization with invalid scanner."""
     with pytest.raises(
-        ValueError, match="Unsupported scanner: invalid. Supported scanners: \\['acs', 'trivy'\\]"
+        ValueError,
+        match="Unsupported scanner: invalid. Supported scanners: \\['acs', 'grype', 'trivy'\\]",
     ):
         VulnerabilityDiffer(
             previous_sbom=test_previous_sbom_path,

--- a/diffusedcli/diffusedcli/cli.py
+++ b/diffusedcli/diffusedcli/cli.py
@@ -69,7 +69,7 @@ def format_vulnerabilities_list(vulnerabilities_list: list, file: Optional[IO[st
 @click.option(
     "-s",
     "--scanner",
-    type=click.Choice(["acs", "trivy"], case_sensitive=False),
+    type=click.Choice(["acs", "grype", "trivy"], case_sensitive=False),
     default="trivy",
     help="Scanner to use for vulnerability detection (default=trivy).",
     required=False,
@@ -138,9 +138,9 @@ def sbom_diff(
     """Show the vulnerability diff between two SBOMs."""
     scanner = ctx.obj["scanner"]
 
-    # Only trivy is supported for SBOM scanning
-    if scanner != "trivy":
-        click.echo(f"Error: Only 'trivy' scanner is supported for SBOM scanning, got '{scanner}'")
+    # ACS does not support SBOM scanning
+    if scanner == "acs":
+        click.echo("Error: SBOM scanning is not supported by the 'acs' scanner")
         exit(1)
 
     if not os.path.isfile(previous_sbom):

--- a/diffusedcli/tests/test_cli.py
+++ b/diffusedcli/tests/test_cli.py
@@ -399,7 +399,7 @@ def test_sbom_diff_with_acs_scanner_error(runner, test_previous_sbom_path, test_
     )
 
     assert result.exit_code == 1
-    assert "Error: Only 'trivy' scanner is supported for SBOM scanning, got 'acs'" in result.output
+    assert "Error: SBOM scanning is not supported by the 'acs' scanner" in result.output
 
 
 def test_sbom_diff_scanner_case_insensitive(runner, test_previous_sbom_path, test_next_sbom_path):


### PR DESCRIPTION
Add GrypeScanner implementation that integrates with the Grype CLI to scan container images and SBOMs. Register it in the differ and CLI alongside the existing ACS and Trivy scanners.