### PR TITLE
docs: add AGENTS.md with AI coding agent guidelines

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,9 @@ jobs:
     - name: Run pytest-cli
       run: tox -e py39-pytest-cli
 
+    - name: Run pytest-repo
+      run: tox -e py39-pytest-repo
+
     - name: Run build-lib
       run: tox -e py39-build-lib
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+Diffused finds fixed container image vulnerabilities by diffing scanner results.
+Stack: Python 3.9+, Click, Rich, Hatchling.
+
+## Architecture
+Scans two versions of an image/SBOM via a third-party scanner. Vulnerabilities in the older scan but missing from the newer are reported as fixed.
+- `diffused/diffused/`: Core lib (`differ.py`, `scanners/` [base, trivy, acs, models])
+- `diffusedcli/diffusedcli/`: CLI package (`cli.py` using Click)
+- `diffused/tests/` & `diffusedcli/tests/`: Pytest suites
+
+## Commands
+- **Setup**: `pip install -e ./diffused/.[dev] && pip install -e ./diffusedcli/.[dev]`
+- **Run all checks**: `tox`
+- **Lint/Type/Format**: `tox -e py39-black,py39-flake8,py39-isort,py39-mypy,black-format`
+- **Test**: `tox -e py39-pytest,py39-pytest-cli`
+
+## Agent Directives
+- **Formatting**: PEP 8. Assume Black and isort with 100-char line length.
+- **Typing**: Type hints are strictly REQUIRED on all functions and methods.
+- **Testing**: Write function-based tests only (no classes). Target 100% coverage.
+- **CLI Testing**: Use `click.testing.CliRunner`. Strip ANSI escape codes when testing `Rich` outputs.
+- **Mocking**: NEVER execute live network requests or binaries in tests. Use fixtures from `diffused/tests/conftest.py` and `diffusedcli/tests/conftest.py` to simulate scanner outputs.
+- **Data Models**: Map raw scanner JSON payloads to `scanners/models.py` immediately. Do not pass raw dictionaries.
+- **Dependencies**: Uses Hatchling. If adding packages, ONLY modify `pyproject.toml`. 
+- **Comments**: Inline comments must always start with a lowercase letter.
+- **Commits**: Use conventional commits (e.g., `feat:`, `fix:`, `chore:`).
+- **Prohibitions**: Do NOT modify `.github/workflows/` or `pyproject.toml` dependencies unless explicitly commanded.

--- a/tests/test_agents_md.py
+++ b/tests/test_agents_md.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+MAX_LINES = 60
+
+
+def test_agents_md_line_count():
+    agents_md = Path(__file__).resolve().parent.parent / "AGENTS.md"
+    line_count = len(agents_md.read_text(encoding="utf-8").splitlines())
+    assert line_count <= MAX_LINES, f"AGENTS.md has {line_count} lines, max is {MAX_LINES}"

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ LIB_SOURCE = diffused/diffused
 LIB_TESTS = diffused/tests
 
 [tox]
-envlist = py39-{black,flake8,isort,mypy,pytest,pytest-cli,build-lib,build-cli}
+envlist = py39-{black,flake8,isort,mypy,pytest,pytest-cli,pytest-repo,build-lib,build-cli}
 isolated_build = True
 
 [testenv]
@@ -58,6 +58,13 @@ commands =
         --cov-fail-under 95 \
         --cov-report xml:coverage-cli.xml \
         {[vars]CLI_TESTS}
+
+[testenv:py39-pytest-repo]
+deps = pytest
+commands =
+    pytest \
+        --verbose \
+        tests/
 
 [testenv:py39-build-lib]
 deps = build


### PR DESCRIPTION
Include a line-count test to enforce the 60-line limit locally and in CI.