### PR TITLE
chore: standardize codecov coverage config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,17 +1,18 @@
 codecov:
-  require_ci_to_pass: true
+  require_ci_to_pass: false
 
 coverage:
-  precision: 2
-  round: down
-  range: "50...100"
-
-flags:
-  unit-tests:
-    carryforward: true
-  cli-tests:
-    carryforward: true
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: 80%
+        informational: true
 
 comment:
-  layout: "reach,diff,flags,files"
-  behavior: default
+  layout: "reach,diff,flags,files,footer"
+  require_changes: true


### PR DESCRIPTION
## Summary

Updates codecov configuration to Konflux standard:
- CI gate disabled (`require_ci_to_pass: false`)
- Patch coverage target: 80% (informational - won't block CI)
- Project coverage target: auto with 1% threshold (informational)
- Comment only on coverage changes

### Why 80% patch target?

The 80% patch coverage target is an org-wide standard being rolled out across all konflux-ci repositories as part of [KFLUXDP-1020](https://redhat.atlassian.net/browse/KFLUXDP-1020). It is set to `informational: true`, meaning it will **never block CI or prevent merging** — it only provides visibility into coverage trends on new/changed code. Teams can adjust the target in future PRs if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KFLUXDP-1020]: https://redhat.atlassian.net/browse/KFLUXDP-1020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ